### PR TITLE
v6.2.1rc1

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,121 @@
+{
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true,
+    "jest": true
+  },
+  "globals": {
+    "globalThis": true
+  },
+  "plugins": [],
+  "overrides": [],
+  "extends": ["eslint:recommended"],
+  "rules": {
+    "arrow-spacing": ["error", { "before": true, "after": true }],
+    "block-spacing": ["error", "always"],
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+    "camelcase": ["error", {
+      "allow": ["^UNSAFE_"],
+      "properties": "never",
+      "ignoreGlobals": true
+    }],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "never",
+      "exports": "never",
+      "functions": "never"
+    }],
+    "comma-spacing": ["error", { "before": false, "after": true }],
+    "eol-last": "error",
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "func-call-spacing": ["error", "never"],
+    "indent": [
+      "error",
+      2,
+      {
+        "MemberExpression": 1,
+        "FunctionDeclaration": {
+          "body": 1,
+          "parameters": 2
+        },
+        "SwitchCase": 1
+      }
+    ],
+    "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
+    "keyword-spacing": ["error", { "before": true, "after": true }],
+    "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
+    "max-len": [
+      "error",
+      {
+        "code": 120,
+        "ignoreTrailingComments": true,
+        "ignoreComments": true,
+        "ignoreUrls": true
+      }
+    ],
+    "max-lines": [
+      "error",
+      {
+        "max": 360,
+        "skipBlankLines": true,
+        "skipComments": false
+      }
+    ],
+    "max-lines-per-function": [
+      "error",
+      {
+        "max": 150,
+        "skipBlankLines": true
+      }
+    ],
+    "max-params": ["error", 3],
+    "no-array-constructor": "error",
+    "no-mixed-spaces-and-tabs": "error",
+    "no-multi-spaces": "error",
+    "no-multi-str": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1,
+        "maxEOF": 0
+      }
+    ],
+    "no-restricted-syntax": [
+        "error",
+        "WithStatement",
+        "BinaryExpression[operator='in']"
+    ],
+    "no-trailing-spaces": "error",
+    "no-use-before-define": [
+      "error",
+      {
+        "functions": true,
+        "classes": true,
+        "variables": false
+      }
+    ],
+    "no-var": "warn",
+    "object-curly-spacing": ["error", "always"],
+    "padded-blocks": [
+      "error",
+      {
+        "blocks": "never",
+        "switches": "never",
+        "classes": "never"
+      }
+    ],
+    "quotes": ["error", "single"],
+    "space-before-blocks": ["error", "always"],
+    "space-before-function-paren": ["error", "always"],
+    "space-infix-ops": "error",
+    "space-unary-ops": ["error", { "words": true, "nonwords": false }],
+    "space-in-parens": ["error", "never"],
+    "semi": ["error", "never"]
+  }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+node_modules
+coverage
+.github
+pnpm-lock.yaml
+examples
+test-data

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,7 @@ This library needs to be simple and flexible to run on multiple platforms such a
 
 ## Coding convention
 
-Please follow [standardjs](https://standardjs.com/) style guide.
-
 Make sure your code lints before opening a pull request.
-
 
 ```bash
 cd feed-extractor

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ yarn add @extractus/feed-extractor
 
 ```ts
 // es6 module
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
 // CommonJS
-const { read } = require('@extractus/feed-extractor')
+const { extract } = require('@extractus/feed-extractor')
 
 // you can specify exactly path to CommonJS version
-const { read } = require('@extractus/feed-extractor/dist/cjs/feed-extractor.js')
+const { extract } = require('@extractus/feed-extractor/dist/cjs/feed-extractor.js')
 
 // extract a RSS
-const result = await read('https://news.google.com/rss')
+const result = await extract('https://news.google.com/rss')
 console.log(result)
 ```
 
@@ -48,16 +48,16 @@ console.log(result)
 
 ```ts
 // deno < 1.28
-import { read } from 'https://esm.sh/@extractus/feed-extractor'
+import { extract } from 'https://esm.sh/@extractus/feed-extractor'
 
 // deno > 1.28
-import { read } from 'npm:@extractus/feed-extractor'
+import { extract } from 'npm:@extractus/feed-extractor'
 ```
 
 ### Browser
 
 ```ts
-import { read } from 'https://unpkg.com/@extractus/feed-extractor@latest/dist/feed-extractor.esm.js'
+import { extract } from 'https://unpkg.com/@extractus/feed-extractor@latest/dist/feed-extractor.esm.js'
 ```
 
 Please check [the examples](https://github.com/extractus/feed-extractor/tree/main/examples) for reference.
@@ -65,36 +65,34 @@ Please check [the examples](https://github.com/extractus/feed-extractor/tree/mai
 
 ## APIs
 
-### `read()`
+- [extract()](#extract)
+- [extractFromJson()](#extractfromjson)
+- [extractFromXml()](#extractfromxml)
+
+#### Note:
+
+- *Old method `read()` has been marked as deprecated and will be removed in next major release.*
+
+---
+
+### `extract()`
 
 Load and extract feed data from given RSS/ATOM/JSON source. Return a Promise object.
 
 #### Syntax
 
 ```ts
-read(String url)
-read(String url, Object options)
-read(String url, Object options, Object fetchOptions)
+extract(String url)
+extract(String url, Object parserOptions)
+extract(String url, Object parserOptions, Object fetchOptions)
 ```
 
-#### Parameters
-
-##### `url` *required*
-
-URL of a valid feed source
-
-Feed content must be accessible and conform one of the following standards:
-
-  - [RSS Feed](https://www.rssboard.org/rss-specification)
-  - [ATOM Feed](https://datatracker.ietf.org/doc/html/rfc5023)
-  - [JSON Feed](https://www.jsonfeed.org/version/1.1/)
-
-For example:
+Example:
 
 ```js
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
-const result = await read('https://news.google.com/atom')
+const result = await extract('https://news.google.com/atom')
 console.log(result)
 ```
 
@@ -121,7 +119,19 @@ Without any options, the result should have the following structure:
 }
 ```
 
-##### `options` *optional*
+#### Parameters
+
+##### `url` *required*
+
+URL of a valid feed source
+
+Feed content must be accessible and conform one of the following standards:
+
+  - [RSS Feed](https://www.rssboard.org/rss-specification)
+  - [ATOM Feed](https://datatracker.ietf.org/doc/html/rfc5023)
+  - [JSON Feed](https://www.jsonfeed.org/version/1.1/)
+
+##### `parserOptions` *optional*
 
 Object with all or several of the following properties:
 
@@ -135,13 +145,13 @@ Object with all or several of the following properties:
 For example:
 
 ```ts
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
-await read('https://news.google.com/atom', {
+await extract('https://news.google.com/atom', {
   useISODateFormat: false
 })
 
-await read('https://news.google.com/rss', {
+await extract('https://news.google.com/rss', {
   useISODateFormat: false,
   getExtraFeedFields: (feedData) => {
     return {
@@ -175,10 +185,10 @@ You can use this param to set request headers to fetch.
 For example:
 
 ```js
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
 const url = 'https://news.google.com/rss'
-await read(url, null, {
+await extract(url, null, {
   headers: {
     'user-agent': 'Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1'
   }
@@ -190,11 +200,11 @@ You can also specify a proxy endpoint to load remote content, instead of fetchin
 For example:
 
 ```js
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
 const url = 'https://news.google.com/rss'
 
-await read(url, null, {
+await extract(url, null, {
   headers: {
     'user-agent': 'Opera/9.60 (Windows NT 6.0; U; en) Presto/2.1.1'
   },
@@ -209,6 +219,85 @@ await read(url, null, {
 
 Passing requests to proxy is useful while running `@extractus/feed-extractor` on browser.
 View `examples/browser-feed-reader` as reference example.
+
+
+### `extractFromJson()`
+
+Extract feed data from JSON string.
+Return an object which contains feed data.
+
+#### Syntax
+
+```ts
+extractFromJson(String json)
+extractFromJson(String json, Object parserOptions)
+```
+
+Example:
+
+```js
+import { extractFromJson } from '@extractus/feed-extractor'
+
+const url = 'https://www.jsonfeed.org/feed.json'
+// this resource provides data in JSON feed format
+// so we fetch remote content as json
+// then pass to feed-extractor
+const res = await fetch(url)
+const json = await res.json()
+
+const feed = extractFromJson(json)
+console.log(feed)
+```
+
+#### Parameters
+
+##### `json` *required*
+
+JSON string loaded from JSON feed resource.
+
+##### `parserOptions` *optional*
+
+See [parserOptions](#parseroptions-optional) above.
+
+
+### `extractFromXml()`
+
+Extract feed data from XML string.
+Return an object which contains feed data.
+
+#### Syntax
+
+```ts
+extractFromXml(String xml)
+extractFromXml(String xml, Object parserOptions)
+```
+
+Example:
+
+```js
+import { extractFromXml } from '@extractus/feed-extractor'
+
+const url = 'https://news.google.com/atom'
+// this resource provides data in ATOM feed format
+// so we fetch remote content as text
+// then pass to feed-extractor
+const res = await fetch(url)
+const xml = await res.text()
+
+const feed = extractFromXml(xml)
+console.log(feed)
+```
+
+#### Parameters
+
+##### `xml` *required*
+
+XML string loaded from RSS/ATOM feed resource.
+
+##### `parserOptions` *optional*
+
+See [parserOptions](#parseroptions-optional) above.
+
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ To read & normalize RSS/ATOM/JSON feed data.
 
 ```bash
 npm i @extractus/feed-extractor
-
-# pnpm
-pnpm i @extractus/feed-extractor
-
-# yarn
-yarn add @extractus/feed-extractor
 ```
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@ To read & normalize RSS/ATOM/JSON feed data.
 ![CodeQL](https://github.com/extractus/feed-extractor/workflows/CodeQL/badge.svg)
 ![CI test](https://github.com/extractus/feed-extractor/workflows/ci-test/badge.svg)
 [![Coverage Status](https://img.shields.io/coveralls/github/extractus/feed-extractor)](https://coveralls.io/github/extractus/feed-extractor?branch=main)
-[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![CodeFactor](https://www.codefactor.io/repository/github/extractus/feed-extractor/badge)](https://www.codefactor.io/repository/github/extractus/feed-extractor)
 
-### Attention
-
-`feed-reader` has been renamed to `@extractus/feed-extractor` since v6.1.4
-
+(This library is derived from [feed-reader](https://www.npmjs.com/package/feed-reader) renamed.)
 
 ## Demo
 

--- a/build.js
+++ b/build.js
@@ -8,7 +8,7 @@ const pkg = JSON.parse(readFileSync('./package.json', { encoding: 'utf-8' }))
 
 rmSync('dist', {
   force: true,
-  recursive: true
+  recursive: true,
 })
 mkdirSync('dist')
 
@@ -16,7 +16,7 @@ const buildTime = (new Date()).toISOString()
 const comment = [
   `// ${pkg.name}@${pkg.version}, by ${pkg.author}`,
   `built with esbuild at ${buildTime}`,
-  `published under ${pkg.license} license`
+  `published under ${pkg.license} license`,
 ].join(' - ')
 
 const baseOpt = {
@@ -28,7 +28,7 @@ const baseOpt = {
   legalComments: 'none',
   minify: false,
   sourcemap: false,
-  write: true
+  write: true,
 }
 
 const esmVersion = {
@@ -37,8 +37,8 @@ const esmVersion = {
   format: 'esm',
   outfile: 'dist/feed-extractor.esm.js',
   banner: {
-    js: comment
-  }
+    js: comment,
+  },
 }
 buildSync(esmVersion)
 
@@ -49,15 +49,15 @@ const cjsVersion = {
   mainFields: ['main'],
   outfile: 'dist/cjs/feed-extractor.js',
   banner: {
-    js: comment
-  }
+    js: comment,
+  },
 }
 buildSync(cjsVersion)
 
 const cjspkg = {
   name: pkg.name,
   version: pkg.version,
-  main: './feed-extractor.js'
+  main: './feed-extractor.js',
 }
 
 writeFileSync(

--- a/dist/cjs/feed-extractor.js
+++ b/dist/cjs/feed-extractor.js
@@ -1,4 +1,4 @@
-// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T03:34:06.797Z - published under MIT license
+// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T04:32:07.629Z - published under MIT license
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/cjs/feed-extractor.js
+++ b/dist/cjs/feed-extractor.js
@@ -1,4 +1,4 @@
-// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T04:32:07.629Z - published under MIT license
+// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T04:44:59.011Z - published under MIT license
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/cjs/feed-extractor.js
+++ b/dist/cjs/feed-extractor.js
@@ -1,4 +1,4 @@
-// @extractus/feed-extractor@6.2.0, by @extractus - built with esbuild at 2023-01-04T04:59:05.957Z - published under MIT license
+// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T03:34:06.797Z - published under MIT license
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -21,6 +21,10 @@ var __copyProps = (to, from, except, desc) => {
   return to;
 };
 var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
   isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
@@ -1145,7 +1149,9 @@ var require_url_state_machine = __commonJS({
           this.url.fragment = "";
           this.state = "fragment";
         } else {
-          if (this.input.length - this.pointer - 1 === 0 || !isWindowsDriveLetterCodePoints(c, this.input[this.pointer + 1]) || this.input.length - this.pointer - 1 >= 2 && !fileOtherwiseCodePoints.has(this.input[this.pointer + 2])) {
+          if (this.input.length - this.pointer - 1 === 0 || // remaining consists of 0 code points
+          !isWindowsDriveLetterCodePoints(c, this.input[this.pointer + 1]) || this.input.length - this.pointer - 1 >= 2 && // remaining has at least 2 code points
+          !fileOtherwiseCodePoints.has(this.input[this.pointer + 2])) {
             this.url.host = this.base.host;
             this.url.path = this.base.path.slice();
             shortenPath(this.url);
@@ -1976,15 +1982,26 @@ var require_lib2 = __commonJS({
       get bodyUsed() {
         return this[INTERNALS].disturbed;
       },
+      /**
+       * Decode response as ArrayBuffer
+       *
+       * @return  Promise
+       */
       arrayBuffer() {
         return consumeBody.call(this).then(function(buf) {
           return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
         });
       },
+      /**
+       * Return raw response as Blob
+       *
+       * @return Promise
+       */
       blob() {
         let ct = this.headers && this.headers.get("content-type") || "";
         return consumeBody.call(this).then(function(buf) {
           return Object.assign(
+            // Prevent copying
             new Blob([], {
               type: ct.toLowerCase()
             }),
@@ -1994,6 +2011,11 @@ var require_lib2 = __commonJS({
           );
         });
       },
+      /**
+       * Decode response as json
+       *
+       * @return  Promise
+       */
       json() {
         var _this2 = this;
         return consumeBody.call(this).then(function(buffer) {
@@ -2004,14 +2026,30 @@ var require_lib2 = __commonJS({
           }
         });
       },
+      /**
+       * Decode response as text
+       *
+       * @return  Promise
+       */
       text() {
         return consumeBody.call(this).then(function(buffer) {
           return buffer.toString();
         });
       },
+      /**
+       * Decode response as buffer (non-spec api)
+       *
+       * @return  Promise
+       */
       buffer() {
         return consumeBody.call(this);
       },
+      /**
+       * Decode response as text, while automatically detecting the encoding and
+       * trying to decode to UTF-8 (non-spec api)
+       *
+       * @return  Promise
+       */
       textConverted() {
         var _this3 = this;
         return consumeBody.call(this).then(function(buffer) {
@@ -2195,7 +2233,8 @@ var require_lib2 = __commonJS({
       } else if (Buffer.isBuffer(body)) {
         return body.length;
       } else if (body && typeof body.getLengthSync === "function") {
-        if (body._lengthRetrievers && body._lengthRetrievers.length == 0 || body.hasKnownLength && body.hasKnownLength()) {
+        if (body._lengthRetrievers && body._lengthRetrievers.length == 0 || // 1.x
+        body.hasKnownLength && body.hasKnownLength()) {
           return body.getLengthSync();
         }
         return null;
@@ -2242,6 +2281,12 @@ var require_lib2 = __commonJS({
     }
     var MAP = Symbol("map");
     var Headers = class {
+      /**
+       * Headers class
+       *
+       * @param   Object  headers  Response headers
+       * @return  Void
+       */
       constructor() {
         let init = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : void 0;
         this[MAP] = /* @__PURE__ */ Object.create(null);
@@ -2286,6 +2331,12 @@ var require_lib2 = __commonJS({
           throw new TypeError("Provided initializer must be an object");
         }
       }
+      /**
+       * Return combined header value given name
+       *
+       * @param   String  name  Header name
+       * @return  Mixed
+       */
       get(name) {
         name = `${name}`;
         validateName(name);
@@ -2295,6 +2346,13 @@ var require_lib2 = __commonJS({
         }
         return this[MAP][key].join(", ");
       }
+      /**
+       * Iterate over all headers
+       *
+       * @param   Function  callback  Executed for each item with parameters (value, name, thisArg)
+       * @param   Boolean   thisArg   `this` context for callback function
+       * @return  Void
+       */
       forEach(callback) {
         let thisArg = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : void 0;
         let pairs = getHeaders(this);
@@ -2307,6 +2365,13 @@ var require_lib2 = __commonJS({
           i++;
         }
       }
+      /**
+       * Overwrite header values given name
+       *
+       * @param   String  name   Header name
+       * @param   String  value  Header value
+       * @return  Void
+       */
       set(name, value) {
         name = `${name}`;
         value = `${value}`;
@@ -2315,6 +2380,13 @@ var require_lib2 = __commonJS({
         const key = find(this[MAP], name);
         this[MAP][key !== void 0 ? key : name] = [value];
       }
+      /**
+       * Append a value onto existing header
+       *
+       * @param   String  name   Header name
+       * @param   String  value  Header value
+       * @return  Void
+       */
       append(name, value) {
         name = `${name}`;
         value = `${value}`;
@@ -2327,11 +2399,23 @@ var require_lib2 = __commonJS({
           this[MAP][name] = [value];
         }
       }
+      /**
+       * Check for header name existence
+       *
+       * @param   String   name  Header name
+       * @return  Boolean
+       */
       has(name) {
         name = `${name}`;
         validateName(name);
         return find(this[MAP], name) !== void 0;
       }
+      /**
+       * Delete all header values given name
+       *
+       * @param   String  name  Header name
+       * @return  Void
+       */
       delete(name) {
         name = `${name}`;
         validateName(name);
@@ -2340,15 +2424,37 @@ var require_lib2 = __commonJS({
           delete this[MAP][key];
         }
       }
+      /**
+       * Return raw headers (non-spec api)
+       *
+       * @return  Object
+       */
       raw() {
         return this[MAP];
       }
+      /**
+       * Get an iterator on keys.
+       *
+       * @return  Iterator
+       */
       keys() {
         return createHeadersIterator(this, "key");
       }
+      /**
+       * Get an iterator on values.
+       *
+       * @return  Iterator
+       */
       values() {
         return createHeadersIterator(this, "value");
       }
+      /**
+       * Get an iterator on entries.
+       *
+       * This is the default iterator of the Headers object.
+       *
+       * @return  Iterator
+       */
       [Symbol.iterator]() {
         return createHeadersIterator(this, "key+value");
       }
@@ -2480,6 +2586,9 @@ var require_lib2 = __commonJS({
       get status() {
         return this[INTERNALS$1].status;
       }
+      /**
+       * Convenience property representing if the request ended normally
+       */
       get ok() {
         return this[INTERNALS$1].status >= 200 && this[INTERNALS$1].status < 300;
       }
@@ -2492,6 +2601,11 @@ var require_lib2 = __commonJS({
       get headers() {
         return this[INTERNALS$1].headers;
       }
+      /**
+       * Clone this response
+       *
+       * @return  Response
+       */
       clone() {
         return new Response(clone(this), {
           url: this.url,
@@ -2601,6 +2715,11 @@ var require_lib2 = __commonJS({
       get signal() {
         return this[INTERNALS$2].signal;
       }
+      /**
+       * Clone this request
+       *
+       * @return  Request
+       */
       clone() {
         return new Request(this);
       }
@@ -2895,9 +3014,9 @@ var require_node_ponyfill = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/util.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/util.js
 var require_util = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/util.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/util.js"(exports) {
     "use strict";
     var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
     var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
@@ -2954,13 +3073,14 @@ var require_util = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/validator.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/validator.js
 var require_validator = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/validator.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/validator.js"(exports) {
     "use strict";
     var util = require_util();
     var defaultOptions = {
       allowBooleanAttributes: false,
+      //A tag can have attributes without any value
       unpairedTags: []
     };
     exports.validate = function(xmlData, options) {
@@ -3255,6 +3375,7 @@ var require_validator = __commonJS({
       const lines = xmlData.substring(0, index).split(/\r?\n/);
       return {
         line: lines.length,
+        // column number is last line's length + 1, because column numbering starts at 1:
         col: lines[lines.length - 1].length + 1
       };
     }
@@ -3264,9 +3385,9 @@ var require_validator = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
 var require_OptionsBuilder = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
     var defaultOptions = {
       preserveOrder: false,
       attributeNamePrefix: "@_",
@@ -3274,10 +3395,14 @@ var require_OptionsBuilder = __commonJS({
       textNodeName: "#text",
       ignoreAttributes: true,
       removeNSPrefix: false,
+      // remove NS from tag name or attribute name if true
       allowBooleanAttributes: false,
+      //a tag can have attributes without any value
+      //ignoreRootElement : false,
       parseTagValue: true,
       parseAttributeValue: false,
       trimValues: true,
+      //Trim string values of tag and attributes
       cdataPropName: false,
       numberParseOptions: {
         hex: true,
@@ -3290,6 +3415,7 @@ var require_OptionsBuilder = __commonJS({
         return val;
       },
       stopNodes: [],
+      //nested tags will not be parsed even for errors
       alwaysCreateTextNode: false,
       isArray: () => false,
       commentPropName: false,
@@ -3298,7 +3424,8 @@ var require_OptionsBuilder = __commonJS({
       htmlEntities: false,
       ignoreDeclaration: false,
       ignorePiTags: false,
-      transformTagName: false
+      transformTagName: false,
+      transformAttributeName: false
     };
     var buildOptions = function(options) {
       return Object.assign({}, defaultOptions, options);
@@ -3308,9 +3435,9 @@ var require_OptionsBuilder = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
 var require_xmlNode = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module2) {
     "use strict";
     var XmlNode = class {
       constructor(tagname) {
@@ -3333,9 +3460,9 @@ var require_xmlNode = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
 var require_DocTypeReader = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module2) {
     function readDocType(xmlData, i) {
       const entities = {};
       if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
@@ -3354,7 +3481,10 @@ var require_DocTypeReader = __commonJS({
               i += 8;
             } else if (hasBody && xmlData[i + 1] === "!" && xmlData[i + 2] === "N" && xmlData[i + 3] === "O" && xmlData[i + 4] === "T" && xmlData[i + 5] === "A" && xmlData[i + 6] === "T" && xmlData[i + 7] === "I" && xmlData[i + 8] === "O" && xmlData[i + 9] === "N") {
               i += 9;
-            } else if (xmlData[i + 1] === "!" && xmlData[i + 2] === "-" && xmlData[i + 3] === "-") {
+            } else if (
+              //comment
+              xmlData[i + 1] === "!" && xmlData[i + 2] === "-" && xmlData[i + 3] === "-"
+            ) {
               comment = true;
             } else {
               throw new Error("Invalid DOCTYPE");
@@ -3420,6 +3550,7 @@ var require_strnum = __commonJS({
       leadingZeros: true,
       decimalPoint: ".",
       eNotation: true
+      //skipLike: /regex/
     };
     function toNumber(str, options = {}) {
       options = Object.assign({}, consider, options);
@@ -3500,9 +3631,9 @@ var require_strnum = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
 var require_OrderedObjParser = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module2) {
     "use strict";
     var util = require_util();
     var xmlNode = require_xmlNode();
@@ -3524,6 +3655,11 @@ var require_OrderedObjParser = __commonJS({
         this.ampEntity = { regex: /&(amp|#38|#x26);/g, val: "&" };
         this.htmlEntities = {
           "space": { regex: /&(nbsp|#160);/g, val: " " },
+          // "lt" : { regex: /&(lt|#60);/g, val: "<" },
+          // "gt" : { regex: /&(gt|#62);/g, val: ">" },
+          // "amp" : { regex: /&(amp|#38);/g, val: "&" },
+          // "quot" : { regex: /&(quot|#34);/g, val: "\"" },
+          // "apos" : { regex: /&(apos|#39);/g, val: "'" },
           "cent": { regex: /&(cent|#162);/g, val: "¢" },
           "pound": { regex: /&(pound|#163);/g, val: "£" },
           "yen": { regex: /&(yen|#165);/g, val: "¥" },
@@ -3601,8 +3737,11 @@ var require_OrderedObjParser = __commonJS({
         for (let i = 0; i < len; i++) {
           const attrName = this.resolveNameSpace(matches[i][1]);
           let oldVal = matches[i][4];
-          const aName = this.options.attributeNamePrefix + attrName;
+          let aName = this.options.attributeNamePrefix + attrName;
           if (attrName.length) {
+            if (this.options.transformAttributeName) {
+              aName = this.options.transformAttributeName(aName);
+            }
             if (oldVal !== void 0) {
               if (this.options.trimValues) {
                 oldVal = oldVal.trim();
@@ -3957,9 +4096,9 @@ var require_OrderedObjParser = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/node2json.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/node2json.js
 var require_node2json = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
     "use strict";
     function prettify(node, options) {
       return compress(node, options);
@@ -4048,9 +4187,9 @@ var require_node2json = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
 var require_XMLParser = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module2) {
     var { buildOptions } = require_OptionsBuilder();
     var OrderedObjParser = require_OrderedObjParser();
     var { prettify } = require_node2json();
@@ -4060,6 +4199,11 @@ var require_XMLParser = __commonJS({
         this.externalEntities = {};
         this.options = buildOptions(options);
       }
+      /**
+       * Parse XML dats to JS object 
+       * @param {string|Buffer} xmlData 
+       * @param {boolean|Object} validationOption 
+       */
       parse(xmlData, validationOption) {
         if (typeof xmlData === "string") {
         } else if (xmlData.toString) {
@@ -4083,6 +4227,11 @@ var require_XMLParser = __commonJS({
         else
           return prettify(orderedResult, this.options);
       }
+      /**
+       * Add Entity which is not by default supported by this library
+       * @param {string} key 
+       * @param {string} value 
+       */
       addEntity(key, value) {
         if (value.indexOf("&") !== -1) {
           throw new Error("Entity value can't have '&'");
@@ -4099,19 +4248,20 @@ var require_XMLParser = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
 var require_orderedJs2Xml = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module2) {
     var EOL = "\n";
     function toXml(jArray, options) {
-      return arrToStr(jArray, options, "", 0);
-    }
-    function arrToStr(arr, options, jPath, level) {
-      let xmlStr = "";
       let indentation = "";
       if (options.format && options.indentBy.length > 0) {
-        indentation = EOL + "" + options.indentBy.repeat(level);
+        indentation = EOL;
       }
+      return arrToStr(jArray, options, "", indentation);
+    }
+    function arrToStr(arr, options, jPath, indentation) {
+      let xmlStr = "";
+      let isPreviousElementTag = false;
       for (let i = 0; i < arr.length; i++) {
         const tagObj = arr[i];
         const tagName = propName(tagObj);
@@ -4126,13 +4276,22 @@ var require_orderedJs2Xml = __commonJS({
             tagText = options.tagValueProcessor(tagName, tagText);
             tagText = replaceEntitiesValue(tagText, options);
           }
-          xmlStr += indentation + tagText;
+          if (isPreviousElementTag) {
+            xmlStr += indentation;
+          }
+          xmlStr += tagText;
+          isPreviousElementTag = false;
           continue;
         } else if (tagName === options.cdataPropName) {
-          xmlStr += indentation + `<![CDATA[${tagObj[tagName][0][options.textNodeName]}]]>`;
+          if (isPreviousElementTag) {
+            xmlStr += indentation;
+          }
+          xmlStr += `<![CDATA[${tagObj[tagName][0][options.textNodeName]}]]>`;
+          isPreviousElementTag = false;
           continue;
         } else if (tagName === options.commentPropName) {
           xmlStr += indentation + `<!--${tagObj[tagName][0][options.textNodeName]}-->`;
+          isPreviousElementTag = true;
           continue;
         } else if (tagName[0] === "?") {
           const attStr2 = attr_to_str(tagObj[":@"], options);
@@ -4140,11 +4299,16 @@ var require_orderedJs2Xml = __commonJS({
           let piTextNodeName = tagObj[tagName][0][options.textNodeName];
           piTextNodeName = piTextNodeName.length !== 0 ? " " + piTextNodeName : "";
           xmlStr += tempInd + `<${tagName}${piTextNodeName}${attStr2}?>`;
+          isPreviousElementTag = true;
           continue;
         }
+        let newIdentation = indentation;
+        if (newIdentation !== "") {
+          newIdentation += options.indentBy;
+        }
         const attStr = attr_to_str(tagObj[":@"], options);
-        let tagStart = indentation + `<${tagName}${attStr}`;
-        let tagValue = arrToStr(tagObj[tagName], options, newJPath, level + 1);
+        const tagStart = indentation + `<${tagName}${attStr}`;
+        const tagValue = arrToStr(tagObj[tagName], options, newJPath, newIdentation);
         if (options.unpairedTags.indexOf(tagName) !== -1) {
           if (options.suppressUnpairedNode)
             xmlStr += tagStart + ">";
@@ -4152,9 +4316,18 @@ var require_orderedJs2Xml = __commonJS({
             xmlStr += tagStart + "/>";
         } else if ((!tagValue || tagValue.length === 0) && options.suppressEmptyNode) {
           xmlStr += tagStart + "/>";
-        } else {
+        } else if (tagValue && tagValue.endsWith(">")) {
           xmlStr += tagStart + `>${tagValue}${indentation}</${tagName}>`;
+        } else {
+          xmlStr += tagStart + ">";
+          if (tagValue && indentation !== "" && (tagValue.includes("/>") || tagValue.includes("</"))) {
+            xmlStr += indentation + options.indentBy + tagValue + indentation;
+          } else {
+            xmlStr += tagValue;
+          }
+          xmlStr += `</${tagName}>`;
         }
+        isPreviousElementTag = true;
       }
       return xmlStr;
     }
@@ -4203,9 +4376,9 @@ var require_orderedJs2Xml = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
 var require_json2xml = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module2) {
     "use strict";
     var buildFromOrderedJs = require_orderedJs2Xml();
     var defaultOptions = {
@@ -4230,14 +4403,16 @@ var require_json2xml = __commonJS({
       unpairedTags: [],
       entities: [
         { regex: new RegExp("&", "g"), val: "&amp;" },
+        //it must be on top
         { regex: new RegExp(">", "g"), val: "&gt;" },
         { regex: new RegExp("<", "g"), val: "&lt;" },
         { regex: new RegExp("'", "g"), val: "&apos;" },
         { regex: new RegExp('"', "g"), val: "&quot;" }
       ],
       processEntities: true,
-      stopNodes: [],
-      transformTagName: false
+      stopNodes: []
+      // transformTagName: false,
+      // transformAttributeName: false,
     };
     function Builder(options) {
       this.options = Object.assign({}, defaultOptions, options);
@@ -4438,9 +4613,9 @@ var require_json2xml = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/fxp.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/fxp.js
 var require_fxp = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/fxp.js"(exports, module2) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/fxp.js"(exports, module2) {
     "use strict";
     var validator = require_validator();
     var XMLParser2 = require_XMLParser();
@@ -4665,6 +4840,9 @@ var require_lib3 = __commonJS({
 // src/main.js
 var main_exports = {};
 __export(main_exports, {
+  extract: () => extract,
+  extractFromJson: () => extractFromJson,
+  extractFromXml: () => extractFromXml,
   read: () => read
 });
 module.exports = __toCommonJS(main_exports);
@@ -5211,15 +5389,7 @@ var parseAtomFeed_default = (data, options = {}) => {
 };
 
 // src/main.js
-var read = async (url, options = {}, fetchOptions = {}) => {
-  if (!isValid(url)) {
-    throw new Error("Input param must be a valid URL");
-  }
-  const data = await retrieve_default(url, fetchOptions);
-  if (!data.text && !data.json) {
-    throw new Error(`Failed to load content from "${url}"`);
-  }
-  const { type, json, text } = data;
+var getopt = (options = {}) => {
   const {
     normalization = true,
     descriptionMaxLen = 210,
@@ -5228,23 +5398,45 @@ var read = async (url, options = {}, fetchOptions = {}) => {
     getExtraFeedFields = () => ({}),
     getExtraEntryFields = () => ({})
   } = options;
-  const opts = {
+  return {
     normalization,
     descriptionMaxLen,
     useISODateFormat,
+    xmlParserOptions,
     getExtraFeedFields,
     getExtraEntryFields
   };
-  if (type === "json") {
-    return parseJsonFeed_default(json, opts);
-  }
-  if (!validate(text)) {
+};
+var extractFromJson = (json, options = {}) => {
+  return parseJsonFeed_default(json, getopt(options));
+};
+var extractFromXml = (xml, options = {}) => {
+  if (!validate(xml)) {
     throw new Error("The XML document is not well-formed");
   }
-  const xml = xml2obj(text, xmlParserOptions);
-  return isRSS(xml) ? parseRssFeed_default(xml, opts) : isAtom(xml) ? parseAtomFeed_default(xml, opts) : null;
+  const opts = getopt(options);
+  const data = xml2obj(xml, opts.xmlParserOptions);
+  return isRSS(data) ? parseRssFeed_default(data, opts) : isAtom(data) ? parseAtomFeed_default(data, opts) : null;
+};
+var extract = async (url, options = {}, fetchOptions = {}) => {
+  if (!isValid(url)) {
+    throw new Error("Input param must be a valid URL");
+  }
+  const data = await retrieve_default(url, fetchOptions);
+  if (!data.text && !data.json) {
+    throw new Error(`Failed to load content from "${url}"`);
+  }
+  const { type, json, text } = data;
+  return type === "json" ? extractFromJson(json, options) : extractFromXml(text, options);
+};
+var read = async (url, options, fetchOptions) => {
+  console.warn("WARNING: read() is deprecated. Please use extract() instead!");
+  return extract(url, options, fetchOptions);
 };
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
+  extract,
+  extractFromJson,
+  extractFromXml,
   read
 });

--- a/dist/cjs/index.d.ts
+++ b/dist/cjs/index.d.ts
@@ -23,7 +23,7 @@ export interface FeedData {
 
 export interface ProxyConfig {
   target?: string;
-  headers?: string[];
+  headers?: any;
 }
 
 export interface ReaderOptions {
@@ -58,15 +58,17 @@ export interface ReaderOptions {
 }
 
 export interface FetchOptions {
-  /**
-   * list of request headers
-   * default: null
-   */
-  headers?: string[];
-  /**
-   * the values to configure proxy
-   * default: null
-   */
+  //  Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>
+  method?: "GET" | "POST" | "DELETE" | "PATCH" | "PUT" | "HEAD" | "OPTIONS" | "CONNECT";
+  headers?: any;
+  body?: any;
+  mode?: "cors" | "no-cors" | "same-origin";
+  credentials?: "omit" | "same-origin" | "include";
+  cache?: "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached";
+  redirect?: "follow" | "error" | "manual";
+  referrer?: string;
+  referrerPolicy?: "referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "unsafe-url";
+  integrity?: any;
   proxy?: ProxyConfig;
 }
 

--- a/dist/cjs/index.d.ts
+++ b/dist/cjs/index.d.ts
@@ -33,16 +33,6 @@ export interface ReaderOptions {
    */
   normalization?: boolean;
   /**
-   * include full content of feed entry if present
-   * default: false
-   */
-  includeEntryContent?: boolean;
-  /**
-   * include optional elements if any
-   * default: false
-   */
-  includeOptionalElements?: boolean;
-  /**
    * convert datetime to ISO format
    * default: true
    */
@@ -79,5 +69,10 @@ export interface FetchOptions {
    */
   proxy?: ProxyConfig;
 }
+
+export function extractFromXml(xml: string, options?: ReaderOptions): FeedData;
+export function extractFromJson(json: string, options?: ReaderOptions): FeedData;
+
+export function extract(url: string, options?: ReaderOptions, fetchOptions?: FetchOptions): Promise<FeedData>;
 
 export function read(url: string, options?: ReaderOptions, fetchOptions?: FetchOptions): Promise<FeedData>;

--- a/dist/cjs/package.json
+++ b/dist/cjs/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@extractus/feed-extractor",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "main": "./feed-extractor.js"
 }

--- a/dist/feed-extractor.esm.js
+++ b/dist/feed-extractor.esm.js
@@ -1,4 +1,4 @@
-// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T03:34:06.797Z - published under MIT license
+// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T04:32:07.629Z - published under MIT license
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/feed-extractor.esm.js
+++ b/dist/feed-extractor.esm.js
@@ -1,4 +1,4 @@
-// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T04:32:07.629Z - published under MIT license
+// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T04:44:59.011Z - published under MIT license
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/dist/feed-extractor.esm.js
+++ b/dist/feed-extractor.esm.js
@@ -1,4 +1,4 @@
-// @extractus/feed-extractor@6.2.0, by @extractus - built with esbuild at 2023-01-04T04:59:05.957Z - published under MIT license
+// @extractus/feed-extractor@6.2.1, by @extractus - built with esbuild at 2023-01-12T03:34:06.797Z - published under MIT license
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
@@ -17,13 +17,17 @@ var __copyProps = (to, from, except, desc) => {
   return to;
 };
 var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
   isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
   mod
 ));
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/util.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/util.js
 var require_util = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/util.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/util.js"(exports) {
     "use strict";
     var nameStartChar = ":A-Za-z_\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD";
     var nameChar = nameStartChar + "\\-.\\d\\u00B7\\u0300-\\u036F\\u203F-\\u2040";
@@ -80,13 +84,14 @@ var require_util = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/validator.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/validator.js
 var require_validator = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/validator.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/validator.js"(exports) {
     "use strict";
     var util = require_util();
     var defaultOptions = {
       allowBooleanAttributes: false,
+      //A tag can have attributes without any value
       unpairedTags: []
     };
     exports.validate = function(xmlData, options) {
@@ -381,6 +386,7 @@ var require_validator = __commonJS({
       const lines = xmlData.substring(0, index).split(/\r?\n/);
       return {
         line: lines.length,
+        // column number is last line's length + 1, because column numbering starts at 1:
         col: lines[lines.length - 1].length + 1
       };
     }
@@ -390,9 +396,9 @@ var require_validator = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js
 var require_OptionsBuilder = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OptionsBuilder.js"(exports) {
     var defaultOptions = {
       preserveOrder: false,
       attributeNamePrefix: "@_",
@@ -400,10 +406,14 @@ var require_OptionsBuilder = __commonJS({
       textNodeName: "#text",
       ignoreAttributes: true,
       removeNSPrefix: false,
+      // remove NS from tag name or attribute name if true
       allowBooleanAttributes: false,
+      //a tag can have attributes without any value
+      //ignoreRootElement : false,
       parseTagValue: true,
       parseAttributeValue: false,
       trimValues: true,
+      //Trim string values of tag and attributes
       cdataPropName: false,
       numberParseOptions: {
         hex: true,
@@ -416,6 +426,7 @@ var require_OptionsBuilder = __commonJS({
         return val;
       },
       stopNodes: [],
+      //nested tags will not be parsed even for errors
       alwaysCreateTextNode: false,
       isArray: () => false,
       commentPropName: false,
@@ -424,7 +435,8 @@ var require_OptionsBuilder = __commonJS({
       htmlEntities: false,
       ignoreDeclaration: false,
       ignorePiTags: false,
-      transformTagName: false
+      transformTagName: false,
+      transformAttributeName: false
     };
     var buildOptions = function(options) {
       return Object.assign({}, defaultOptions, options);
@@ -434,9 +446,9 @@ var require_OptionsBuilder = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js
 var require_xmlNode = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/xmlNode.js"(exports, module) {
     "use strict";
     var XmlNode = class {
       constructor(tagname) {
@@ -459,9 +471,9 @@ var require_xmlNode = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js
 var require_DocTypeReader = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/DocTypeReader.js"(exports, module) {
     function readDocType(xmlData, i) {
       const entities = {};
       if (xmlData[i + 3] === "O" && xmlData[i + 4] === "C" && xmlData[i + 5] === "T" && xmlData[i + 6] === "Y" && xmlData[i + 7] === "P" && xmlData[i + 8] === "E") {
@@ -480,7 +492,10 @@ var require_DocTypeReader = __commonJS({
               i += 8;
             } else if (hasBody && xmlData[i + 1] === "!" && xmlData[i + 2] === "N" && xmlData[i + 3] === "O" && xmlData[i + 4] === "T" && xmlData[i + 5] === "A" && xmlData[i + 6] === "T" && xmlData[i + 7] === "I" && xmlData[i + 8] === "O" && xmlData[i + 9] === "N") {
               i += 9;
-            } else if (xmlData[i + 1] === "!" && xmlData[i + 2] === "-" && xmlData[i + 3] === "-") {
+            } else if (
+              //comment
+              xmlData[i + 1] === "!" && xmlData[i + 2] === "-" && xmlData[i + 3] === "-"
+            ) {
               comment = true;
             } else {
               throw new Error("Invalid DOCTYPE");
@@ -546,6 +561,7 @@ var require_strnum = __commonJS({
       leadingZeros: true,
       decimalPoint: ".",
       eNotation: true
+      //skipLike: /regex/
     };
     function toNumber(str, options = {}) {
       options = Object.assign({}, consider, options);
@@ -626,9 +642,9 @@ var require_strnum = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js
 var require_OrderedObjParser = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/OrderedObjParser.js"(exports, module) {
     "use strict";
     var util = require_util();
     var xmlNode = require_xmlNode();
@@ -650,6 +666,11 @@ var require_OrderedObjParser = __commonJS({
         this.ampEntity = { regex: /&(amp|#38|#x26);/g, val: "&" };
         this.htmlEntities = {
           "space": { regex: /&(nbsp|#160);/g, val: " " },
+          // "lt" : { regex: /&(lt|#60);/g, val: "<" },
+          // "gt" : { regex: /&(gt|#62);/g, val: ">" },
+          // "amp" : { regex: /&(amp|#38);/g, val: "&" },
+          // "quot" : { regex: /&(quot|#34);/g, val: "\"" },
+          // "apos" : { regex: /&(apos|#39);/g, val: "'" },
           "cent": { regex: /&(cent|#162);/g, val: "¢" },
           "pound": { regex: /&(pound|#163);/g, val: "£" },
           "yen": { regex: /&(yen|#165);/g, val: "¥" },
@@ -727,8 +748,11 @@ var require_OrderedObjParser = __commonJS({
         for (let i = 0; i < len; i++) {
           const attrName = this.resolveNameSpace(matches[i][1]);
           let oldVal = matches[i][4];
-          const aName = this.options.attributeNamePrefix + attrName;
+          let aName = this.options.attributeNamePrefix + attrName;
           if (attrName.length) {
+            if (this.options.transformAttributeName) {
+              aName = this.options.transformAttributeName(aName);
+            }
             if (oldVal !== void 0) {
               if (this.options.trimValues) {
                 oldVal = oldVal.trim();
@@ -1083,9 +1107,9 @@ var require_OrderedObjParser = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/node2json.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/node2json.js
 var require_node2json = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/node2json.js"(exports) {
     "use strict";
     function prettify(node, options) {
       return compress(node, options);
@@ -1174,9 +1198,9 @@ var require_node2json = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js
 var require_XMLParser = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlparser/XMLParser.js"(exports, module) {
     var { buildOptions } = require_OptionsBuilder();
     var OrderedObjParser = require_OrderedObjParser();
     var { prettify } = require_node2json();
@@ -1186,6 +1210,11 @@ var require_XMLParser = __commonJS({
         this.externalEntities = {};
         this.options = buildOptions(options);
       }
+      /**
+       * Parse XML dats to JS object 
+       * @param {string|Buffer} xmlData 
+       * @param {boolean|Object} validationOption 
+       */
       parse(xmlData, validationOption) {
         if (typeof xmlData === "string") {
         } else if (xmlData.toString) {
@@ -1209,6 +1238,11 @@ var require_XMLParser = __commonJS({
         else
           return prettify(orderedResult, this.options);
       }
+      /**
+       * Add Entity which is not by default supported by this library
+       * @param {string} key 
+       * @param {string} value 
+       */
       addEntity(key, value) {
         if (value.indexOf("&") !== -1) {
           throw new Error("Entity value can't have '&'");
@@ -1225,19 +1259,20 @@ var require_XMLParser = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js
 var require_orderedJs2Xml = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/orderedJs2Xml.js"(exports, module) {
     var EOL = "\n";
     function toXml(jArray, options) {
-      return arrToStr(jArray, options, "", 0);
-    }
-    function arrToStr(arr, options, jPath, level) {
-      let xmlStr = "";
       let indentation = "";
       if (options.format && options.indentBy.length > 0) {
-        indentation = EOL + "" + options.indentBy.repeat(level);
+        indentation = EOL;
       }
+      return arrToStr(jArray, options, "", indentation);
+    }
+    function arrToStr(arr, options, jPath, indentation) {
+      let xmlStr = "";
+      let isPreviousElementTag = false;
       for (let i = 0; i < arr.length; i++) {
         const tagObj = arr[i];
         const tagName = propName(tagObj);
@@ -1252,13 +1287,22 @@ var require_orderedJs2Xml = __commonJS({
             tagText = options.tagValueProcessor(tagName, tagText);
             tagText = replaceEntitiesValue(tagText, options);
           }
-          xmlStr += indentation + tagText;
+          if (isPreviousElementTag) {
+            xmlStr += indentation;
+          }
+          xmlStr += tagText;
+          isPreviousElementTag = false;
           continue;
         } else if (tagName === options.cdataPropName) {
-          xmlStr += indentation + `<![CDATA[${tagObj[tagName][0][options.textNodeName]}]]>`;
+          if (isPreviousElementTag) {
+            xmlStr += indentation;
+          }
+          xmlStr += `<![CDATA[${tagObj[tagName][0][options.textNodeName]}]]>`;
+          isPreviousElementTag = false;
           continue;
         } else if (tagName === options.commentPropName) {
           xmlStr += indentation + `<!--${tagObj[tagName][0][options.textNodeName]}-->`;
+          isPreviousElementTag = true;
           continue;
         } else if (tagName[0] === "?") {
           const attStr2 = attr_to_str(tagObj[":@"], options);
@@ -1266,11 +1310,16 @@ var require_orderedJs2Xml = __commonJS({
           let piTextNodeName = tagObj[tagName][0][options.textNodeName];
           piTextNodeName = piTextNodeName.length !== 0 ? " " + piTextNodeName : "";
           xmlStr += tempInd + `<${tagName}${piTextNodeName}${attStr2}?>`;
+          isPreviousElementTag = true;
           continue;
         }
+        let newIdentation = indentation;
+        if (newIdentation !== "") {
+          newIdentation += options.indentBy;
+        }
         const attStr = attr_to_str(tagObj[":@"], options);
-        let tagStart = indentation + `<${tagName}${attStr}`;
-        let tagValue = arrToStr(tagObj[tagName], options, newJPath, level + 1);
+        const tagStart = indentation + `<${tagName}${attStr}`;
+        const tagValue = arrToStr(tagObj[tagName], options, newJPath, newIdentation);
         if (options.unpairedTags.indexOf(tagName) !== -1) {
           if (options.suppressUnpairedNode)
             xmlStr += tagStart + ">";
@@ -1278,9 +1327,18 @@ var require_orderedJs2Xml = __commonJS({
             xmlStr += tagStart + "/>";
         } else if ((!tagValue || tagValue.length === 0) && options.suppressEmptyNode) {
           xmlStr += tagStart + "/>";
-        } else {
+        } else if (tagValue && tagValue.endsWith(">")) {
           xmlStr += tagStart + `>${tagValue}${indentation}</${tagName}>`;
+        } else {
+          xmlStr += tagStart + ">";
+          if (tagValue && indentation !== "" && (tagValue.includes("/>") || tagValue.includes("</"))) {
+            xmlStr += indentation + options.indentBy + tagValue + indentation;
+          } else {
+            xmlStr += tagValue;
+          }
+          xmlStr += `</${tagName}>`;
         }
+        isPreviousElementTag = true;
       }
       return xmlStr;
     }
@@ -1329,9 +1387,9 @@ var require_orderedJs2Xml = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js
 var require_json2xml = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/xmlbuilder/json2xml.js"(exports, module) {
     "use strict";
     var buildFromOrderedJs = require_orderedJs2Xml();
     var defaultOptions = {
@@ -1356,14 +1414,16 @@ var require_json2xml = __commonJS({
       unpairedTags: [],
       entities: [
         { regex: new RegExp("&", "g"), val: "&amp;" },
+        //it must be on top
         { regex: new RegExp(">", "g"), val: "&gt;" },
         { regex: new RegExp("<", "g"), val: "&lt;" },
         { regex: new RegExp("'", "g"), val: "&apos;" },
         { regex: new RegExp('"', "g"), val: "&quot;" }
       ],
       processEntities: true,
-      stopNodes: [],
-      transformTagName: false
+      stopNodes: []
+      // transformTagName: false,
+      // transformAttributeName: false,
     };
     function Builder(options) {
       this.options = Object.assign({}, defaultOptions, options);
@@ -1564,9 +1624,9 @@ var require_json2xml = __commonJS({
   }
 });
 
-// node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/fxp.js
+// node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/fxp.js
 var require_fxp = __commonJS({
-  "node_modules/.pnpm/fast-xml-parser@4.0.12/node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
+  "node_modules/.pnpm/fast-xml-parser@4.0.13/node_modules/fast-xml-parser/src/fxp.js"(exports, module) {
     "use strict";
     var validator = require_validator();
     var XMLParser2 = require_XMLParser();
@@ -2332,15 +2392,7 @@ var parseAtomFeed_default = (data, options = {}) => {
 };
 
 // src/main.js
-var read = async (url, options = {}, fetchOptions = {}) => {
-  if (!isValid(url)) {
-    throw new Error("Input param must be a valid URL");
-  }
-  const data = await retrieve_default(url, fetchOptions);
-  if (!data.text && !data.json) {
-    throw new Error(`Failed to load content from "${url}"`);
-  }
-  const { type, json, text } = data;
+var getopt = (options = {}) => {
   const {
     normalization = true,
     descriptionMaxLen = 210,
@@ -2349,22 +2401,44 @@ var read = async (url, options = {}, fetchOptions = {}) => {
     getExtraFeedFields = () => ({}),
     getExtraEntryFields = () => ({})
   } = options;
-  const opts = {
+  return {
     normalization,
     descriptionMaxLen,
     useISODateFormat,
+    xmlParserOptions,
     getExtraFeedFields,
     getExtraEntryFields
   };
-  if (type === "json") {
-    return parseJsonFeed_default(json, opts);
-  }
-  if (!validate(text)) {
+};
+var extractFromJson = (json, options = {}) => {
+  return parseJsonFeed_default(json, getopt(options));
+};
+var extractFromXml = (xml, options = {}) => {
+  if (!validate(xml)) {
     throw new Error("The XML document is not well-formed");
   }
-  const xml = xml2obj(text, xmlParserOptions);
-  return isRSS(xml) ? parseRssFeed_default(xml, opts) : isAtom(xml) ? parseAtomFeed_default(xml, opts) : null;
+  const opts = getopt(options);
+  const data = xml2obj(xml, opts.xmlParserOptions);
+  return isRSS(data) ? parseRssFeed_default(data, opts) : isAtom(data) ? parseAtomFeed_default(data, opts) : null;
+};
+var extract = async (url, options = {}, fetchOptions = {}) => {
+  if (!isValid(url)) {
+    throw new Error("Input param must be a valid URL");
+  }
+  const data = await retrieve_default(url, fetchOptions);
+  if (!data.text && !data.json) {
+    throw new Error(`Failed to load content from "${url}"`);
+  }
+  const { type, json, text } = data;
+  return type === "json" ? extractFromJson(json, options) : extractFromXml(text, options);
+};
+var read = async (url, options, fetchOptions) => {
+  console.warn("WARNING: read() is deprecated. Please use extract() instead!");
+  return extract(url, options, fetchOptions);
 };
 export {
+  extract,
+  extractFromJson,
+  extractFromXml,
   read
 };

--- a/examples/browser-feed-reader/package.json
+++ b/examples/browser-feed-reader/package.json
@@ -6,7 +6,7 @@
     "start": "node server"
   },
   "dependencies": {
-    "express": "^4.18.1",
-    "got": "^12.5.0"
+    "express": "^4.18.2",
+    "got": "^12.5.3"
   }
 }

--- a/examples/browser-feed-reader/public/index.html
+++ b/examples/browser-feed-reader/public/index.html
@@ -45,10 +45,10 @@
     </div>
   </body>
   <script type="module">
-    import { read } from 'https://unpkg.com/@extractus/feed-extractor@latest/dist/feed-extractor.esm.js'
+    import { extract } from 'https://unpkg.com/@extractus/feed-extractor@latest/dist/feed-extractor.esm.js'
 
     const loadFeed = async (url, useProxy = false) => {
-      const data = await read(url, {
+      const data = await extract(url, {
         useISODateFormat: true,
         includeEntryContent: false
       }, {

--- a/examples/browser-feed-reader/server.js
+++ b/examples/browser-feed-reader/server.js
@@ -8,7 +8,7 @@ const app = express()
 const loadRemoteFeed = async (url) => {
   try {
     const headers = {
-      'Accept-Charset': 'utf-8'
+      'Accept-Charset': 'utf-8',
     }
     const data = await got(url, { headers }).text()
     return data

--- a/examples/bun-feed-reader/README.md
+++ b/examples/bun-feed-reader/README.md
@@ -17,18 +17,15 @@ Open `http://localhost:3103/?url=https://news.google.com/rss` to see the result.
 
 You can specify the following options via query string parameters:
 
-- `includeEntryContent`
-- `includeOptionalElements`
-- `useISODateFormat`
 - `normalization`
+- `useISODateFormat`
 
 These params can be set to  `y` or `n`, with `y` is truthy, `n` is falsy.
 
 For examples:
 
 ```
-http://localhost:3103/?url=https://news.google.com/rss&includeEntryContent=y&useISODateFormat=n&includeOptionalElements=y
+http://localhost:3103/?normalization=y&useISODateFormat=y&url=https://news.google.com/rss
 ```
-
 
 ---

--- a/examples/bun-feed-reader/index.ts
+++ b/examples/bun-feed-reader/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
 const app = new Hono()
 
@@ -16,20 +16,16 @@ app.get('/', async (c) => {
   if (!url) {
     return c.json(meta)
   }
-  const includeEntryContent = c.req.query('includeEntryContent') || 'n'
-  const includeOptionalElements = c.req.query('includeOptionalElements') || 'n'
   const useISODateFormat = c.req.query('useISODateFormat') || 'y'
   const normalization = c.req.query('normalization') || 'y'
 
   const opts = {
-    includeEntryContent: includeEntryContent === 'y',
-    includeOptionalElements: includeOptionalElements === 'y',
     useISODateFormat: useISODateFormat !== 'n',
     normalization: normalization !== 'n'
   }
 
   try {
-    const data = await read(url, opts)
+    const data = await extract(url, opts)
     return c.json({
       error: 0,
       message: 'feed data has been extracted successfully',

--- a/examples/bun-feed-reader/package.json
+++ b/examples/bun-feed-reader/package.json
@@ -2,10 +2,10 @@
   "name": "bun-feed-reader",
   "module": "index.ts",
   "devDependencies": {
-    "bun-types": "^0.1.0"
+    "bun-types": "^0.4.0"
   },
   "dependencies": {
     "@extractus/feed-extractor": "latest",
-    "hono": "^2.1.4"
+    "hono": "^2.7.2"
   }
 }

--- a/examples/deno-feed-reader/README.md
+++ b/examples/deno-feed-reader/README.md
@@ -11,17 +11,15 @@ Open `http://localhost:3103/?url=https://news.google.com/rss` to see the result.
 
 You can specify the following options via query string parameters:
 
-- `includeEntryContent`
-- `includeOptionalElements`
-- `useISODateFormat`
 - `normalization`
+- `useISODateFormat`
 
 These params can be set to  `y` or `n`, with `y` is truthy, `n` is falsy.
 
 For examples:
 
 ```
-http://localhost:3103/?url=https://news.google.com/rss&includeEntryContent=y&useISODateFormat=n&includeOptionalElements=y
+http://localhost:3103/?normalization=y&useISODateFormat=y&url=https://news.google.com/rss
 ```
 
 ---

--- a/examples/deno-feed-reader/README.md
+++ b/examples/deno-feed-reader/README.md
@@ -3,6 +3,10 @@
 With `deno`, we have not much thing to do. Just start the server:
 
 ```bash
+# reload if needed
+deno cache --reload index.ts
+
+# start server
 deno run --allow-net --allow-env --allow-read index.ts
 ```
 

--- a/examples/deno-feed-reader/index.ts
+++ b/examples/deno-feed-reader/index.ts
@@ -3,10 +3,10 @@ import { serve } from 'https://deno.land/std/http/server.ts'
 import { Hono } from 'https://deno.land/x/hono@v2.1.4/mod.ts'
 
 // for deno > 1.28 only
-import { read } from 'npm:@extractus/feed-extractor'
+import { extract } from 'npm:@extractus/feed-extractor'
 
 // for deno < 1.28
-// import { read } from 'https://esm.sh/@extractus/feed-extractor'
+// import { extract } from 'https://esm.sh/@extractus/feed-extractor'
 
 const app = new Hono()
 
@@ -22,20 +22,16 @@ app.get('/', async (c) => {
   if (!url) {
     return c.json(meta)
   }
-  const includeEntryContent = c.req.query('includeEntryContent') || 'n'
-  const includeOptionalElements = c.req.query('includeOptionalElements') || 'n'
   const useISODateFormat = c.req.query('useISODateFormat') || 'y'
   const normalization = c.req.query('normalization') || 'y'
 
   const opts = {
-    includeEntryContent: includeEntryContent === 'y',
-    includeOptionalElements: includeOptionalElements === 'y',
     useISODateFormat: useISODateFormat !== 'n',
     normalization: normalization !== 'n'
   }
 
   try {
-    const data = await read(url, opts)
+    const data = await extract(url, opts)
     return c.json({
       error: 0,
       message: 'feed data has been extracted successfully',

--- a/examples/node-feed-reader/README.md
+++ b/examples/node-feed-reader/README.md
@@ -19,17 +19,15 @@ Open `http://localhost:3103/?url=https://news.google.com/rss` to see the result.
 
 You can specify the following options via query string parameters:
 
-- `includeEntryContent`
-- `includeOptionalElements`
-- `useISODateFormat`
 - `normalization`
+- `useISODateFormat`
 
 These params can be set to  `y` or `n`, with `y` is truthy, `n` is falsy.
 
 For examples:
 
 ```
-http://localhost:3103/?url=https://news.google.com/rss&includeEntryContent=y&useISODateFormat=n&includeOptionalElements=y
+http://localhost:3103/?normalization=y&useISODateFormat=y&url=https://news.google.com/rss
 ```
 
 ---

--- a/examples/node-feed-reader/index.js
+++ b/examples/node-feed-reader/index.js
@@ -1,5 +1,5 @@
 import express from 'express'
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
 const app = express()
 
@@ -17,21 +17,17 @@ app.get('/', async (req, res) => {
   }
 
   const {
-    includeEntryContent = 'n',
-    includeOptionalElements = 'n',
     useISODateFormat = 'y',
     normalization = 'y',
   } = req.query
 
   const opts = {
-    includeEntryContent: includeEntryContent === 'y',
-    includeOptionalElements: includeOptionalElements === 'y',
     useISODateFormat: useISODateFormat !== 'n',
     normalization: normalization !== 'n',
   }
 
   try {
-    const data = await read(url, opts)
+    const data = await extract(url, opts)
     return res.json({
       error: 0,
       message: 'feed data has been extracted successfully',

--- a/examples/node-feed-reader/index.js
+++ b/examples/node-feed-reader/index.js
@@ -7,7 +7,7 @@ const meta = {
   service: 'feed-reader',
   lang: 'javascript',
   server: 'express',
-  platform: 'node'
+  platform: 'node',
 }
 
 app.get('/', async (req, res) => {
@@ -20,14 +20,14 @@ app.get('/', async (req, res) => {
     includeEntryContent = 'n',
     includeOptionalElements = 'n',
     useISODateFormat = 'y',
-    normalization = 'y'
+    normalization = 'y',
   } = req.query
 
   const opts = {
     includeEntryContent: includeEntryContent === 'y',
     includeOptionalElements: includeOptionalElements === 'y',
     useISODateFormat: useISODateFormat !== 'n',
-    normalization: normalization !== 'n'
+    normalization: normalization !== 'n',
   }
 
   try {
@@ -36,14 +36,14 @@ app.get('/', async (req, res) => {
       error: 0,
       message: 'feed data has been extracted successfully',
       data,
-      meta
+      meta,
     })
   } catch (err) {
     return res.json({
       error: 1,
       message: err.message,
       data: null,
-      meta
+      meta,
     })
   }
 })

--- a/examples/node-feed-reader/package.json
+++ b/examples/node-feed-reader/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "@extractus/feed-extractor": "latest",
-    "express": "^4.18.1"
+    "express": "^4.18.2"
   }
 }

--- a/examples/tsnode-feed-reader/index.ts
+++ b/examples/tsnode-feed-reader/index.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { read } from '@extractus/feed-extractor'
+import { extract } from '@extractus/feed-extractor'
 
 const app = express()
 
@@ -17,21 +17,17 @@ app.get('/', async (req, res) => {
   }
 
   const {
-    includeEntryContent = 'n',
-    includeOptionalElements = 'n',
     useISODateFormat = 'y',
     normalization = 'y'
   } = req.query
 
   const opts = {
-    includeEntryContent: includeEntryContent === 'y',
-    includeOptionalElements: includeOptionalElements === 'y',
     useISODateFormat: useISODateFormat !== 'n',
     normalization: normalization !== 'n'
   }
 
   try {
-    const data = await read(url, opts)
+    const data = await extract(url, opts)
     return res.json({
       error: 0,
       message: 'feed data has been extracted successfully',

--- a/examples/tsnode-feed-reader/package.json
+++ b/examples/tsnode-feed-reader/package.json
@@ -7,10 +7,10 @@
     "start": "node dist/index.js"
   },
   "devDependencies": {
-    "typescript": "^4.8.3"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "@extractus/feed-extractor": "latest",
-    "express": "^4.18.1"
+    "express": "^4.18.2"
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,9 @@ export interface FetchOptions {
   proxy?: ProxyConfig;
 }
 
-export function extractFromXml(xml: string, options?: ReaderOptions): object<FeedData>;
-export function extractFromJson(json: string, options?: ReaderOptions): object<FeedData>;
+export function extractFromXml(xml: string, options?: ReaderOptions): FeedData;
+export function extractFromJson(json: string, options?: ReaderOptions): FeedData;
+
 export function extract(url: string, options?: ReaderOptions, fetchOptions?: FetchOptions): Promise<FeedData>;
+
 export function read(url: string, options?: ReaderOptions, fetchOptions?: FetchOptions): Promise<FeedData>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ export interface FeedData {
 
 export interface ProxyConfig {
   target?: string;
-  headers?: string[];
+  headers?: any;
 }
 
 export interface ReaderOptions {
@@ -58,15 +58,17 @@ export interface ReaderOptions {
 }
 
 export interface FetchOptions {
-  /**
-   * list of request headers
-   * default: null
-   */
-  headers?: string[];
-  /**
-   * the values to configure proxy
-   * default: null
-   */
+  //  Definitions by: Ryan Graham <https://github.com/ryan-codingintrigue>
+  method?: "GET" | "POST" | "DELETE" | "PATCH" | "PUT" | "HEAD" | "OPTIONS" | "CONNECT";
+  headers?: any;
+  body?: any;
+  mode?: "cors" | "no-cors" | "same-origin";
+  credentials?: "omit" | "same-origin" | "include";
+  cache?: "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached";
+  redirect?: "follow" | "error" | "manual";
+  referrer?: string;
+  referrerPolicy?: "referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "unsafe-url";
+  integrity?: any;
   proxy?: ProxyConfig;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,16 +33,6 @@ export interface ReaderOptions {
    */
   normalization?: boolean;
   /**
-   * include full content of feed entry if present
-   * default: false
-   */
-  includeEntryContent?: boolean;
-  /**
-   * include optional elements if any
-   * default: false
-   */
-  includeOptionalElements?: boolean;
-  /**
    * convert datetime to ISO format
    * default: true
    */
@@ -80,4 +70,7 @@ export interface FetchOptions {
   proxy?: ProxyConfig;
 }
 
+export function extractFromXml(xml: string, options?: ReaderOptions): object<FeedData>;
+export function extractFromJson(json: string, options?: ReaderOptions): object<FeedData>;
+export function extract(url: string, options?: ReaderOptions, fetchOptions?: FetchOptions): Promise<FeedData>;
 export function read(url: string, options?: ReaderOptions, fetchOptions?: FetchOptions): Promise<FeedData>;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.1rc3",
+  "version": "6.2.1",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
   "homepage": "https://github.com/extractus/feed-extractor",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.1rc4",
+  "version": "6.2.1",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
   "homepage": "https://github.com/extractus/feed-extractor",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.1",
+  "version": "6.2.1rc4",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
   "homepage": "https://github.com/extractus/feed-extractor",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "node": ">= 14"
   },
   "scripts": {
-    "lint": "standard .",
-    "lint:fix": "standard --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --verbose --coverage=true",
     "eval": "node eval",
@@ -36,20 +36,14 @@
   "dependencies": {
     "bellajs": "^11.1.1",
     "cross-fetch": "^3.1.5",
-    "fast-xml-parser": "^4.0.12",
+    "fast-xml-parser": "^4.0.13",
     "html-entities": "^2.3.3"
   },
   "devDependencies": {
-    "esbuild": "^0.16.13",
+    "esbuild": "^0.16.17",
+    "eslint": "^8.31.0",
     "jest": "^29.3.1",
-    "nock": "^13.2.9",
-    "standard": "^17.0.0"
-  },
-  "standard": {
-    "ignore": [
-      "/dist",
-      "/examples"
-    ]
+    "nock": "^13.3.0"
   },
   "keywords": [
     "extractor",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.1rc2",
+  "version": "6.2.1rc3",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
   "homepage": "https://github.com/extractus/feed-extractor",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.0",
+  "version": "6.2.1rc1",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
   "homepage": "https://github.com/extractus/feed-extractor",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.2.1rc1",
+  "version": "6.2.1rc2",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
   "homepage": "https://github.com/extractus/feed-extractor",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "6.2.1",
   "name": "@extractus/feed-extractor",
   "description": "To read and normalize RSS/ATOM/JSON feed data",
-  "homepage": "https://github.com/extractus/feed-extractor",
+  "homepage": "https://extractor-demos.pages.dev",
   "repository": {
     "type": "git",
     "url": "git@github.com:extractus/feed-extractor.git"

--- a/reset.js
+++ b/reset.js
@@ -13,14 +13,14 @@ const dirs = [
   '.nyc_output',
   'coverage',
   'node_modules',
-  '.nuxt'
+  '.nuxt',
 ]
 
 const files = [
   'yarn.lock',
   'pnpm-lock.yaml',
   'package-lock.json',
-  'coverage.lcov'
+  'coverage.lcov',
 ]
 
 dirs.forEach((d) => {

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ export const read = async (url, options = {}, fetchOptions = {}) => {
     useISODateFormat = true,
     xmlParserOptions = {},
     getExtraFeedFields = () => ({}),
-    getExtraEntryFields = () => ({})
+    getExtraEntryFields = () => ({}),
   } = options
 
   const opts = {
@@ -33,7 +33,7 @@ export const read = async (url, options = {}, fetchOptions = {}) => {
     descriptionMaxLen,
     useISODateFormat,
     getExtraFeedFields,
-    getExtraEntryFields
+    getExtraEntryFields,
   }
 
   if (type === 'json') {

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -7,7 +7,7 @@ import nock from 'nock'
 
 import { hasProperty, isString } from 'bellajs'
 
-import { read } from './main.js'
+import { extract, read } from './main.js'
 import { isValid as isValidUrl } from './utils/linker.js'
 
 const feedAttrs = 'title link description generator language published entries'.split(' ')
@@ -34,56 +34,56 @@ const validateProps = (entry) => {
     isString(published) && isValidDate(published)
 }
 
-describe('test read() function with common issues', () => {
-  test('read feed from a non-string link', () => {
-    expect(read([])).rejects.toThrow(new Error('Input param must be a valid URL'))
+describe('test extract() function with common issues', () => {
+  test('extract feed from a non-string link', () => {
+    expect(extract([])).rejects.toThrow(new Error('Input param must be a valid URL'))
   })
 
-  test('read feed from a 404 link', () => {
+  test('extract feed from a 404 link', () => {
     const url = 'https://somewhere.xyz/alpha/beta'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(404)
-    expect(read(url)).rejects.toThrow(new Error('Request failed with error code 404'))
+    expect(extract(url)).rejects.toThrow(new Error('Request failed with error code 404'))
   })
 
-  test('read feed from empty xml', () => {
+  test('extract feed from empty xml', () => {
     const url = 'https://empty-source.elsewhere/rss'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, '', {
       'Content-Type': 'application/xml',
     })
-    expect(read(url)).rejects.toThrow(new Error(`Failed to load content from "${url}"`))
+    expect(extract(url)).rejects.toThrow(new Error(`Failed to load content from "${url}"`))
   })
 
-  test('read feed from invalid xml', async () => {
+  test('extract feed from invalid xml', async () => {
     const url = 'https://averybad-source.elsewhere/rss'
     const xml = '<?xml version="1.0" encoding="UTF-8><noop><oops></ooops>'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    expect(read(url)).rejects.toThrow(new Error('The XML document is not well-formed'))
+    expect(extract(url)).rejects.toThrow(new Error('The XML document is not well-formed'))
   })
 
-  test('read feed from invalid json', async () => {
+  test('extract feed from invalid json', async () => {
     const url = 'https://averybad-source.elsewhere/jsonfeed'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, 'this is not json string', {
       'Content-Type': 'application/json',
     })
-    expect(read(url)).rejects.toThrow(new Error('Failed to convert data to JSON object'))
+    expect(extract(url)).rejects.toThrow(new Error('Failed to convert data to JSON object'))
   })
 })
 
-describe('test read() standard feed', () => {
-  test('read rss feed from Google', async () => {
+describe('test extract() standard feed', () => {
+  test('extract rss feed from Google', async () => {
     const url = 'https://some-news-page.tld/rss'
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url)
+    const result = await extract(url)
     feedAttrs.forEach((k) => {
       expect(hasProperty(result, k)).toBe(true)
     })
@@ -93,14 +93,14 @@ describe('test read() standard feed', () => {
     expect(validateProps(result.entries[0])).toBe(true)
   })
 
-  test('read atom feed from Google', async () => {
+  test('extract atom feed from Google', async () => {
     const url = 'https://some-news-page.tld/atom'
     const xml = readFileSync('test-data/atom-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url)
+    const result = await extract(url)
     feedAttrs.forEach((k) => {
       expect(hasProperty(result, k)).toBe(true)
     })
@@ -110,14 +110,14 @@ describe('test read() standard feed', () => {
     expect(validateProps(result.entries[0])).toBe(true)
   })
 
-  test('read atom feed from Google with extraFields', async () => {
+  test('extract atom feed from Google with extraFields', async () => {
     const url = 'https://some-news-page.tld/atom'
     const xml = readFileSync('test-data/atom-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       getExtraFeedFields: data => {
         return {
           author: data.author,
@@ -134,14 +134,14 @@ describe('test read() standard feed', () => {
     expect(validateProps(result.entries[0])).toBe(true)
   })
 
-  test('read atom feed which contains multi links', async () => {
+  test('extract atom feed which contains multi links', async () => {
     const url = 'https://some-news-page.tld/atom/multilinks'
     const xml = readFileSync('test-data/atom-multilinks.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url)
+    const result = await extract(url)
     feedAttrs.forEach((k) => {
       expect(hasProperty(result, k)).toBe(true)
     })
@@ -151,14 +151,14 @@ describe('test read() standard feed', () => {
     expect(validateProps(result.entries[0])).toBe(true)
   })
 
-  test('read json feed from Micro.blog', async () => {
+  test('extract json feed from Micro.blog', async () => {
     const url = 'https://some-news-page.tld/json'
     const json = readFileSync('test-data/json-feed-standard-realworld.json', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, json, {
       'Content-Type': 'text/json',
     })
-    const result = await read(url)
+    const result = await extract(url)
     feedAttrs.forEach((k) => {
       expect(hasProperty(result, k)).toBe(true)
     })
@@ -168,14 +168,14 @@ describe('test read() standard feed', () => {
     expect(validateProps(result.entries[0])).toBe(true)
   })
 
-  test('read json feed from Micro.blog with extra fields', async () => {
+  test('extract json feed from Micro.blog with extra fields', async () => {
     const url = 'https://some-news-page.tld/json'
     const json = readFileSync('test-data/json-feed-standard-realworld.json', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, json, {
       'Content-Type': 'text/json',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       getExtraFeedFields: data => {
         return {
           icon: data.icon,
@@ -192,14 +192,14 @@ describe('test read() standard feed', () => {
     expect(validateProps(result.entries[0])).toBe(true)
   })
 
-  test('read rss feed from huggingface.co (no link)', async () => {
+  test('extract rss feed from huggingface.co (no link)', async () => {
     const url = 'https://huggingface.co/no-link/rss'
     const xml = readFileSync('test-data/rss-feed-miss-link.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url)
+    const result = await extract(url)
     feedAttrs.forEach((k) => {
       expect(hasProperty(result, k)).toBe(true)
     })
@@ -210,7 +210,7 @@ describe('test read() standard feed', () => {
   })
 })
 
-describe('test read() with `useISODateFormat` option', () => {
+describe('test extract() with `useISODateFormat` option', () => {
   test('set `useISODateFormat` to false', async () => {
     const url = 'https://realworld-standard-feed.tld/rss'
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
@@ -218,7 +218,7 @@ describe('test read() with `useISODateFormat` option', () => {
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       useISODateFormat: false,
     })
     expect(result.published).toEqual('Thu, 28 Jul 2022 03:39:57 GMT')
@@ -232,7 +232,7 @@ describe('test read() with `useISODateFormat` option', () => {
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       useISODateFormat: true,
     })
     expect(result.published).toEqual('2022-07-28T03:39:57.000Z')
@@ -240,29 +240,29 @@ describe('test read() with `useISODateFormat` option', () => {
   })
 })
 
-describe('test read() without normalization', () => {
-  test('read rss feed from Google', async () => {
+describe('test extract() without normalization', () => {
+  test('extract rss feed from Google', async () => {
     const url = 'https://some-news-page.tld/rss'
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       normalization: false,
     })
     expect(hasProperty(result, 'webMaster')).toBe(true)
     expect(hasProperty(result, 'item')).toBe(true)
     expect(hasProperty(result.item[0], 'source')).toBe(true)
   })
-  test('read rss feed from standard example', async () => {
+  test('extract rss feed from standard example', async () => {
     const url = 'https://some-news-page.tld/rss'
     const xml = readFileSync('test-data/rss-feed-standard.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       normalization: false,
     })
     expect(hasProperty(result, 'copyright')).toBe(true)
@@ -270,14 +270,14 @@ describe('test read() without normalization', () => {
     expect(hasProperty(result.item, 'guid')).toBe(true)
   })
 
-  test('read atom feed from Google', async () => {
+  test('extract atom feed from Google', async () => {
     const url = 'https://some-news-page.tld/atom'
     const xml = readFileSync('test-data/atom-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       normalization: false,
     })
     expect(hasProperty(result, 'id')).toBe(true)
@@ -286,14 +286,14 @@ describe('test read() without normalization', () => {
     expect(hasProperty(result.entry[0], 'updated')).toBe(true)
   })
 
-  test('read atom feed from standard example', async () => {
+  test('extract atom feed from standard example', async () => {
     const url = 'https://some-news-page.tld/atom'
     const xml = readFileSync('test-data/atom-feed-standard.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       normalization: false,
     })
     expect(hasProperty(result, 'id')).toBe(true)
@@ -304,14 +304,14 @@ describe('test read() without normalization', () => {
     expect(hasProperty(result.entry, 'content')).toBe(true)
   })
 
-  test('read json feed from Micro.blog', async () => {
+  test('extract json feed from Micro.blog', async () => {
     const url = 'https://some-news-page.tld/json'
     const json = readFileSync('test-data/json-feed-standard-realworld.json', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, json, {
       'Content-Type': 'application/json',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       normalization: false,
     })
     expect(hasProperty(result, 'icon')).toBe(true)
@@ -321,17 +321,33 @@ describe('test read() without normalization', () => {
     expect(hasProperty(result.items[0], 'date_published')).toBe(true)
   })
 
-  test('read rss podcast feed with enclosure tag', async () => {
+  test('extract rss podcast feed with enclosure tag', async () => {
     const url = 'https://some-podcast-page.tld/podcast/rss'
     const xml = readFileSync('test-data/podcast.rss', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
       'Content-Type': 'application/xml',
     })
-    const result = await read(url, {
+    const result = await extract(url, {
       normalization: false,
     })
     expect(hasProperty(result, 'itunes:owner')).toBe(true)
     expect(hasProperty(result.item[0], 'itunes:duration')).toBe(true)
+  })
+})
+
+describe('check old method read()', () => {
+  test('ensure that depricated method read() still works', async () => {
+    const url = 'https://realworld-standard-feed.tld/rss'
+    const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
+    const { baseUrl, path } = parseUrl(url)
+    nock(baseUrl).get(path).reply(200, xml, {
+      'Content-Type': 'application/xml',
+    })
+    const result = await read(url, {
+      useISODateFormat: true,
+    })
+    expect(result.published).toEqual('2022-07-28T03:39:57.000Z')
+    expect(result.entries[0].published).toEqual('2022-07-28T02:43:00.000Z')
   })
 })

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -17,7 +17,7 @@ const parseUrl = (url) => {
   const re = new URL(url)
   return {
     baseUrl: `${re.protocol}//${re.host}`,
-    path: re.pathname
+    path: re.pathname,
   }
 }
 
@@ -50,7 +50,7 @@ describe('test read() function with common issues', () => {
     const url = 'https://empty-source.elsewhere/rss'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, '', {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     expect(read(url)).rejects.toThrow(new Error(`Failed to load content from "${url}"`))
   })
@@ -60,7 +60,7 @@ describe('test read() function with common issues', () => {
     const xml = '<?xml version="1.0" encoding="UTF-8><noop><oops></ooops>'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     expect(read(url)).rejects.toThrow(new Error('The XML document is not well-formed'))
   })
@@ -69,19 +69,19 @@ describe('test read() function with common issues', () => {
     const url = 'https://averybad-source.elsewhere/jsonfeed'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, 'this is not json string', {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
     })
     expect(read(url)).rejects.toThrow(new Error('Failed to convert data to JSON object'))
   })
 })
 
-describe('test read() standard feed', (done) => {
+describe('test read() standard feed', () => {
   test('read rss feed from Google', async () => {
     const url = 'https://some-news-page.tld/rss'
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url)
     feedAttrs.forEach((k) => {
@@ -98,7 +98,7 @@ describe('test read() standard feed', (done) => {
     const xml = readFileSync('test-data/atom-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url)
     feedAttrs.forEach((k) => {
@@ -115,19 +115,19 @@ describe('test read() standard feed', (done) => {
     const xml = readFileSync('test-data/atom-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
       getExtraFeedFields: data => {
         return {
-          author: data.author
+          author: data.author,
         }
       },
       getExtraEntryFields: data => {
         return {
-          id: data.id
+          id: data.id,
         }
-      }
+      },
     })
     expect(hasProperty(result, 'author')).toBe(true)
     expect(hasProperty(result.entries[0], 'id')).toBe(true)
@@ -139,7 +139,7 @@ describe('test read() standard feed', (done) => {
     const xml = readFileSync('test-data/atom-multilinks.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url)
     feedAttrs.forEach((k) => {
@@ -156,7 +156,7 @@ describe('test read() standard feed', (done) => {
     const json = readFileSync('test-data/json-feed-standard-realworld.json', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, json, {
-      'Content-Type': 'text/json'
+      'Content-Type': 'text/json',
     })
     const result = await read(url)
     feedAttrs.forEach((k) => {
@@ -173,19 +173,19 @@ describe('test read() standard feed', (done) => {
     const json = readFileSync('test-data/json-feed-standard-realworld.json', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, json, {
-      'Content-Type': 'text/json'
+      'Content-Type': 'text/json',
     })
     const result = await read(url, {
       getExtraFeedFields: data => {
         return {
-          icon: data.icon
+          icon: data.icon,
         }
       },
       getExtraEntryFields: data => {
         return {
-          id: data.id
+          id: data.id,
         }
-      }
+      },
     })
     expect(hasProperty(result, 'icon')).toBe(true)
     expect(hasProperty(result.entries[0], 'id')).toBe(true)
@@ -197,7 +197,7 @@ describe('test read() standard feed', (done) => {
     const xml = readFileSync('test-data/rss-feed-miss-link.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url)
     feedAttrs.forEach((k) => {
@@ -216,10 +216,10 @@ describe('test read() with `useISODateFormat` option', () => {
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      useISODateFormat: false
+      useISODateFormat: false,
     })
     expect(result.published).toEqual('Thu, 28 Jul 2022 03:39:57 GMT')
     expect(result.entries[0].published).toEqual('Thu, 28 Jul 2022 02:43:00 GMT')
@@ -230,10 +230,10 @@ describe('test read() with `useISODateFormat` option', () => {
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      useISODateFormat: true
+      useISODateFormat: true,
     })
     expect(result.published).toEqual('2022-07-28T03:39:57.000Z')
     expect(result.entries[0].published).toEqual('2022-07-28T02:43:00.000Z')
@@ -246,10 +246,10 @@ describe('test read() without normalization', () => {
     const xml = readFileSync('test-data/rss-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      normalization: false
+      normalization: false,
     })
     expect(hasProperty(result, 'webMaster')).toBe(true)
     expect(hasProperty(result, 'item')).toBe(true)
@@ -260,10 +260,10 @@ describe('test read() without normalization', () => {
     const xml = readFileSync('test-data/rss-feed-standard.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      normalization: false
+      normalization: false,
     })
     expect(hasProperty(result, 'copyright')).toBe(true)
     expect(hasProperty(result, 'item')).toBe(true)
@@ -275,10 +275,10 @@ describe('test read() without normalization', () => {
     const xml = readFileSync('test-data/atom-feed-standard-realworld.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      normalization: false
+      normalization: false,
     })
     expect(hasProperty(result, 'id')).toBe(true)
     expect(hasProperty(result, 'rights')).toBe(true)
@@ -291,10 +291,10 @@ describe('test read() without normalization', () => {
     const xml = readFileSync('test-data/atom-feed-standard.xml', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      normalization: false
+      normalization: false,
     })
     expect(hasProperty(result, 'id')).toBe(true)
     expect(hasProperty(result, 'entry')).toBe(true)
@@ -309,10 +309,10 @@ describe('test read() without normalization', () => {
     const json = readFileSync('test-data/json-feed-standard-realworld.json', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, json, {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
     })
     const result = await read(url, {
-      normalization: false
+      normalization: false,
     })
     expect(hasProperty(result, 'icon')).toBe(true)
     expect(hasProperty(result, 'favicon')).toBe(true)
@@ -326,10 +326,10 @@ describe('test read() without normalization', () => {
     const xml = readFileSync('test-data/podcast.rss', 'utf8')
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, xml, {
-      'Content-Type': 'application/xml'
+      'Content-Type': 'application/xml',
     })
     const result = await read(url, {
-      normalization: false
+      normalization: false,
     })
     expect(hasProperty(result, 'itunes:owner')).toBe(true)
     expect(hasProperty(result.item[0], 'itunes:duration')).toBe(true)

--- a/src/utils/linker.js
+++ b/src/utils/linker.js
@@ -75,7 +75,7 @@ const blacklistKeys = [
   'WT.srch',
   'pk_source',
   'pk_medium',
-  'pk_campaign'
+  'pk_campaign',
 ]
 
 export const purify = (url) => {

--- a/src/utils/linker.test.js
+++ b/src/utils/linker.test.js
@@ -7,36 +7,36 @@ describe('test exported methods from `linker`', () => {
   const cases = [
     {
       url: 'https://www.23hq.com',
-      expected: true
+      expected: true,
     },
     {
       url: 'https://secure.actblue.com',
-      expected: true
+      expected: true,
     },
     {
       url: 'https://docs.microsoft.com/en-us/azure/iot-edge/quickstart?view=iotedge-2018-06',
-      expected: true
+      expected: true,
     },
     {
       url: 'http://192.168.1.199:8081/example/page',
-      expected: true
+      expected: true,
     },
     {
       url: 'ftp://192.168.1.199:8081/example/page',
-      expected: false
+      expected: false,
     },
     {
       url: '',
-      expected: false
+      expected: false,
     },
     {
       url: null,
-      expected: false
+      expected: false,
     },
     {
       url: { a: 'x' },
-      expected: false
-    }
+      expected: false,
+    },
   ]
   cases.forEach(({ url, expected }) => {
     test(`isValid("${url}") must return "${expected}"`, () => {
@@ -48,37 +48,37 @@ describe('test exported methods from `linker`', () => {
   const entries = [
     {
       full: '',
-      expected: ''
+      expected: '',
     },
     {
       relative: {},
-      expected: ''
+      expected: '',
     },
     {
       full: 'https://some.where/article/abc-xyz',
       relative: 'category/page.html',
-      expected: 'https://some.where/article/category/page.html'
+      expected: 'https://some.where/article/category/page.html',
     },
     {
       full: 'https://some.where/article/abc-xyz',
       relative: '../category/page.html',
-      expected: 'https://some.where/category/page.html'
+      expected: 'https://some.where/category/page.html',
     },
     {
       full: 'https://some.where/blog/authors/article/abc-xyz',
       relative: '/category/page.html',
-      expected: 'https://some.where/category/page.html'
+      expected: 'https://some.where/category/page.html',
     },
     {
       full: 'https://some.where/article/abc-xyz',
-      expected: 'https://some.where/article/abc-xyz'
-    }
+      expected: 'https://some.where/article/abc-xyz',
+    },
   ]
   entries.forEach((entry) => {
     const {
       full,
       relative,
-      expected
+      expected,
     } = entry
     test(`absolutify("${full}", "${relative}") must become "${expected}"`, () => {
       const result = absolutify(full, relative)
@@ -91,7 +91,7 @@ describe('test exported methods from `linker`', () => {
       null,
       '',
       123,
-      {}
+      {},
     ]
     urls.forEach((url) => {
       const result = purify(url)
@@ -103,33 +103,33 @@ describe('test exported methods from `linker`', () => {
     const entries = [
       {
         url: 'https://some.where/article/abc-xyz',
-        expected: 'https://some.where/article/abc-xyz'
+        expected: 'https://some.where/article/abc-xyz',
       },
       {
         url: 'https://some.where/article/abc-xyz#name,bob',
-        expected: 'https://some.where/article/abc-xyz'
+        expected: 'https://some.where/article/abc-xyz',
       },
       {
         url: 'https://some.where/article/abc-xyz?utm_source=news4&utm_medium=email&utm_campaign=spring-summer',
-        expected: 'https://some.where/article/abc-xyz'
+        expected: 'https://some.where/article/abc-xyz',
       },
       {
         url: 'https://some.where/article/abc-xyz?q=3&utm_source=news4&utm_medium=email&utm_campaign=spring-summer',
-        expected: 'https://some.where/article/abc-xyz?q=3'
+        expected: 'https://some.where/article/abc-xyz?q=3',
       },
       {
         url: 'https://some.where/article/abc-xyz?pk_source=news4&pk_medium=email&pk_campaign=spring-summer',
-        expected: 'https://some.where/article/abc-xyz'
+        expected: 'https://some.where/article/abc-xyz',
       },
       {
         url: 'https://some.where/article/abc-xyz?q=3&pk_source=news4&pk_medium=email&pk_campaign=spring-summer',
-        expected: 'https://some.where/article/abc-xyz?q=3'
-      }
+        expected: 'https://some.where/article/abc-xyz?q=3',
+      },
     ]
     entries.forEach((entry) => {
       const {
         url,
-        expected
+        expected,
       } = entry
       const result = purify(url)
       expect(result).toEqual(expected)

--- a/src/utils/normalizer.js
+++ b/src/utils/normalizer.js
@@ -75,18 +75,18 @@ export const getEnclosure = (val) => {
   return !url || !type
     ? null
     : {
-        url,
-        type,
-        length
-      }
+      url,
+      type,
+      length,
+    }
 }
 
 const getCategory = (v) => {
   return isObject(v)
     ? {
-        text: getText(v),
-        domain: v['@_domain']
-      }
+      text: getText(v),
+      domain: v['@_domain'],
+    }
     : v
 }
 
@@ -94,7 +94,7 @@ export const getOptionalTags = (val, key) => {
   if (key === 'source') {
     return {
       text: getText(val),
-      url: getLink(val)
+      url: getLink(val),
     }
   }
   if (key === 'category') {

--- a/src/utils/parseAtomFeed.js
+++ b/src/utils/parseAtomFeed.js
@@ -17,7 +17,7 @@ const transform = (item, options) => {
   const {
     useISODateFormat,
     descriptionMaxLen,
-    getExtraEntryFields
+    getExtraEntryFields,
   } = options
 
   const {
@@ -29,7 +29,7 @@ const transform = (item, options) => {
     published = '',
     link = '',
     summary = '',
-    content = ''
+    content = '',
   } = item
 
   const pubDate = updated || modified || published || issued
@@ -39,14 +39,14 @@ const transform = (item, options) => {
     title: getText(title),
     link: getPureUrl(link, id),
     published: useISODateFormat ? toISODateString(pubDate) : pubDate,
-    description: buildDescription(htmlContent || summary, descriptionMaxLen)
+    description: buildDescription(htmlContent || summary, descriptionMaxLen),
   }
 
   const extraFields = getExtraEntryFields(item)
 
   return {
     ...entry,
-    ...extraFields
+    ...extraFields,
   }
 }
 
@@ -55,7 +55,7 @@ const flatten = (feed) => {
     id,
     title = '',
     link = '',
-    entry
+    entry,
   } = feed
 
   const entries = isArray(entry) ? entry : [entry]
@@ -65,12 +65,12 @@ const flatten = (feed) => {
       title = '',
       link = '',
       summary = '',
-      content = ''
+      content = '',
     } = entry
     const item = {
       ...entry,
       title: getText(title),
-      link: getPureUrl(link, id)
+      link: getPureUrl(link, id),
     }
     if (hasProperty(item, 'summary')) {
       item.summary = getText(summary)
@@ -85,7 +85,7 @@ const flatten = (feed) => {
     ...feed,
     title: getText(title),
     link: getPureUrl(link, id),
-    entry: isArray(entry) ? items : items[0]
+    entry: isArray(entry) ? items : items[0],
   }
   return output
 }
@@ -93,7 +93,7 @@ const flatten = (feed) => {
 const parseAtom = (data, options = {}) => {
   const {
     normalization,
-    getExtraFeedFields
+    getExtraFeedFields,
   } = options
 
   if (!normalization) {
@@ -108,7 +108,7 @@ const parseAtom = (data, options = {}) => {
     generator = '',
     language = '',
     updated = '',
-    entry: item = []
+    entry: item = [],
   } = data.feed
 
   const extraFields = getExtraFeedFields(data.feed)
@@ -127,7 +127,7 @@ const parseAtom = (data, options = {}) => {
     ...extraFields,
     entries: items.map((item) => {
       return transform(item, options)
-    })
+    }),
   }
 }
 

--- a/src/utils/parseJsonFeed.js
+++ b/src/utils/parseJsonFeed.js
@@ -16,7 +16,7 @@ const transform = (item, options) => {
   const {
     useISODateFormat,
     descriptionMaxLen,
-    getExtraEntryFields
+    getExtraEntryFields,
   } = options
 
   const {
@@ -26,7 +26,7 @@ const transform = (item, options) => {
     date_published: pubDate = '',
     summary = '',
     content_html: htmlContent = '',
-    content_text: textContent = ''
+    content_text: textContent = '',
   } = item
 
   const published = useISODateFormat ? toISODateString(pubDate) : pubDate
@@ -37,19 +37,19 @@ const transform = (item, options) => {
     title,
     link: purifyUrl(link),
     published,
-    description: buildDescription(textContent || htmlContent || summary, descriptionMaxLen)
+    description: buildDescription(textContent || htmlContent || summary, descriptionMaxLen),
   }
 
   return {
     ...entry,
-    ...extraFields
+    ...extraFields,
   }
 }
 
 const parseJson = (data, options) => {
   const {
     normalization,
-    getExtraFeedFields
+    getExtraFeedFields,
   } = options
 
   if (!normalization) {
@@ -61,7 +61,7 @@ const parseJson = (data, options) => {
     home_page_url: homepageUrl = '',
     description = '',
     language = '',
-    items: item = []
+    items: item = [],
   } = data
 
   const extraFields = getExtraFeedFields(data)
@@ -78,7 +78,7 @@ const parseJson = (data, options) => {
     ...extraFields,
     entries: items.map((item) => {
       return transform(item, options)
-    })
+    }),
   }
 }
 

--- a/src/utils/parseRssFeed.js
+++ b/src/utils/parseRssFeed.js
@@ -17,7 +17,7 @@ const transform = (item, options) => {
   const {
     useISODateFormat,
     descriptionMaxLen,
-    getExtraEntryFields
+    getExtraEntryFields,
   } = options
 
   const {
@@ -25,7 +25,7 @@ const transform = (item, options) => {
     title = '',
     link = '',
     pubDate = '',
-    description = ''
+    description = '',
   } = item
 
   const published = useISODateFormat ? toISODateString(pubDate) : pubDate
@@ -35,14 +35,14 @@ const transform = (item, options) => {
     title: getText(title),
     link: getPureUrl(link, guid),
     published,
-    description: buildDescription(description, descriptionMaxLen)
+    description: buildDescription(description, descriptionMaxLen),
   }
 
   const extraFields = getExtraEntryFields(item)
 
   return {
     ...entry,
-    ...extraFields
+    ...extraFields,
   }
 }
 
@@ -50,7 +50,7 @@ const flatten = (feed) => {
   const {
     title = '',
     link = '',
-    item
+    item,
   } = feed
 
   const items = isArray(item) ? item : [item]
@@ -58,13 +58,13 @@ const flatten = (feed) => {
     const {
       id,
       title = '',
-      link = ''
+      link = '',
     } = entry
 
     const item = {
       ...entry,
       title: getText(title),
-      link: getPureUrl(link, id)
+      link: getPureUrl(link, id),
     }
 
     const txtTags = 'guid description source'.split(' ')
@@ -89,7 +89,7 @@ const flatten = (feed) => {
     ...feed,
     title: getText(title),
     link: getPureUrl(link),
-    item: isArray(item) ? entries : entries[0]
+    item: isArray(item) ? entries : entries[0],
   }
   return output
 }
@@ -97,7 +97,7 @@ const flatten = (feed) => {
 const parseRss = (data, options = {}) => {
   const {
     normalization,
-    getExtraFeedFields
+    getExtraFeedFields,
   } = options
 
   if (!normalization) {
@@ -111,7 +111,7 @@ const parseRss = (data, options = {}) => {
     generator = '',
     language = '',
     lastBuildDate = '',
-    item = []
+    item = [],
   } = data.rss.channel
 
   const extraFields = getExtraFeedFields(data.rss.channel)
@@ -130,7 +130,7 @@ const parseRss = (data, options = {}) => {
     ...extraFields,
     entries: items.map((item) => {
       return transform(item, options)
-    })
+    }),
   }
 }
 

--- a/src/utils/retrieve.js
+++ b/src/utils/retrieve.js
@@ -5,10 +5,10 @@ import fetch from 'cross-fetch'
 const profetch = async (url, proxy = {}) => {
   const {
     target,
-    headers = {}
+    headers = {},
   } = proxy
   const res = await fetch(target + encodeURIComponent(url), {
-    headers
+    headers,
   })
   return res
 }
@@ -16,9 +16,9 @@ const profetch = async (url, proxy = {}) => {
 export default async (url, options = {}) => {
   const {
     headers = {
-      'user-agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0'
+      'user-agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0',
     },
-    proxy = null
+    proxy = null,
   } = options
 
   const res = proxy ? await profetch(url, proxy) : await fetch(url, { headers })

--- a/src/utils/retrieve.test.js
+++ b/src/utils/retrieve.test.js
@@ -9,7 +9,7 @@ const parseUrl = (url) => {
   const re = new URL(url)
   return {
     baseUrl: `${re.protocol}//${re.host}`,
-    path: re.pathname
+    path: re.pathname,
   }
 }
 
@@ -25,7 +25,7 @@ describe('test retrieve() method', () => {
     const url = 'https://some.where/bad/page'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, '<?xml version="1.0"?><tag>this is xml</tag>', {
-      'Content-Type': 'something/type'
+      'Content-Type': 'something/type',
     })
     expect(retrieve(url)).rejects.toThrow(new Error('Invalid content type: something/type'))
   })
@@ -34,7 +34,7 @@ describe('test retrieve() method', () => {
     const url = 'https://some.where/good/page'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, '<div>this is content</div>', {
-      'Content-Type': 'application/rss+xml'
+      'Content-Type': 'application/rss+xml',
     })
     const result = await retrieve(url)
     expect(result.type).toEqual('xml')
@@ -45,7 +45,7 @@ describe('test retrieve() method', () => {
     const url = 'https://some.where/good/page'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, '\n\r\r\n\n<div>this is content</div>\n\r\r\n\n', {
-      'Content-Type': 'text/xml'
+      'Content-Type': 'text/xml',
     })
     const result = await retrieve(url)
     expect(result.type).toEqual('xml')
@@ -56,18 +56,18 @@ describe('test retrieve() method', () => {
     const url = 'https://some.where/good/source-with-proxy'
     const { baseUrl, path } = parseUrl(url)
     nock(baseUrl).get(path).reply(200, 'something bad', {
-      'Content-Type': 'bad/thing'
+      'Content-Type': 'bad/thing',
     })
     nock('https://proxy-server.com')
       .get('/api/proxy?url=https%3A%2F%2Fsome.where%2Fgood%2Fsource-with-proxy')
       .reply(200, '<?xml version="1.0"?><tag>this is xml</tag>', {
-        'Content-Type': 'text/xml'
+        'Content-Type': 'text/xml',
       })
 
     const result = await retrieve(url, {
       proxy: {
-        target: 'https://proxy-server.com/api/proxy?url='
-      }
+        target: 'https://proxy-server.com/api/proxy?url=',
+      },
     })
     expect(result.type).toEqual('xml')
     expect(result.text).toEqual('<?xml version="1.0"?><tag>this is xml</tag>')

--- a/src/utils/xmlparser.js
+++ b/src/utils/xmlparser.js
@@ -20,7 +20,7 @@ export const xml2obj = (xml = '', extraOptions = {}) => {
   const options = {
     ...extraOptions,
     ignoreAttributes: false,
-    attributeNamePrefix: '@_'
+    attributeNamePrefix: '@_',
   }
   const parser = new XMLParser(options)
   const jsonObj = parser.parse(xml)


### PR DESCRIPTION
- Replace `read()` by `extract()`
  - Mark `read()` as deprecated method
- Add new methods: `extractFromJson()` & `extractFromXml()` (#80)
- Change coding convention (remove standardjs)
- Update dependencies
