### PR TITLE
Add missing `types` in `exports` section of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "./src/main.js",
   "type": "module",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./src/main.js",
     "require": "./dist/cjs/feed-extractor.js"
   },


### PR DESCRIPTION
This PR adds missing `types` in `exports` section of package.json.
This fixes the issue of not getting type info from the package.

![Screenshot 2023-05-11 132056](https://github.com/extractus/feed-extractor/assets/15786310/63344a1f-17a8-4765-8aa3-e9e6c0ae2f48)


Fixes: https://github.com/extractus/feed-extractor/issues/85