### PR TITLE
Support cjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ pnpm-lock.yaml
 
 output.json
 deno.lock
+
+bundle.cjs
+bundle.cjs.map

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ import { extract } from 'https://esm.sh/@extractus/feed-extractor'
 
 Please check [the examples](https://github.com/extractus/feed-extractor/tree/main/examples) for reference.
 
+## CJS Deprecated
+
+CJS is deprecated for this package.  When calling `require('@extractus/feed-extractor')` a deprecation warning is now logged.  You should update your code to use the ESM export.
+
+- You can ignore this warning via the environment variable `FEED_EXTRACTOR_CJS_IGNORE_WARNING=true`
+- To see where the warning is coming from you can set the environment variable `FEED_EXTRACTOR_CJS_TRACE_WARNING=true`
+
 
 ## APIs
 

--- a/build.js
+++ b/build.js
@@ -1,0 +1,20 @@
+import { build } from 'esbuild'
+import fs from 'fs'
+
+const { dependencies } = JSON.parse(fs.readFileSync('./package.json', 'utf8'))
+// we need esbuild to process esm dependencies while leaving cjs compatible ones
+// out of the bundle
+const esmDependencies = new Set(['bellajs'])
+const externalDeps = Object.keys(dependencies)
+  .filter(dep => !esmDependencies.has(dep))
+
+build({
+  entryPoints: ['./src/main.js'],
+  bundle: true,
+  platform: 'node',
+  target: 'node16',
+  outfile: 'bundle.cjs',
+  minify: true,
+  sourcemap: true,
+  external: externalDeps,
+})

--- a/build.js
+++ b/build.js
@@ -9,7 +9,7 @@ const externalDeps = Object.keys(dependencies)
   .filter(dep => !esmDependencies.has(dep))
 
 build({
-  entryPoints: ['./src/main.js'],
+  entryPoints: ['./src/cjs-entry.js'],
   bundle: true,
   platform: 'node',
   target: 'node16',

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
   "author": "@extractus",
   "main": "./src/main.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./src/main.js",
+      "require": "./bundle.cjs",
+      "default": "./src/main.js"
+    }
+  },
   "imports": {
     "cross-fetch": "./src/deno/cross-fetch.js"
   },
@@ -23,6 +31,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "build": "node build",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --verbose --coverage=true",
     "eval": "node eval",
@@ -35,6 +44,7 @@
     "html-entities": "^2.4.0"
   },
   "devDependencies": {
+    "esbuild": "^0.19.8",
     "eslint": "^8.53.0",
     "https-proxy-agent": "^7.0.2",
     "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "build": "node build",
+    "prepublishOnly": "npm run build",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --verbose --coverage=true",
     "eval": "node eval",

--- a/src/cjs-entry.js
+++ b/src/cjs-entry.js
@@ -1,0 +1,14 @@
+function warnCjsUsage () {
+  if (process.env.FEED_EXTRACTOR_CJS_IGNORE_WARNING?.toLowerCase() === 'true') return
+  const yellow = (str) => `\u001b[33m${str}\u001b[39m`
+  const log = process.env.FEED_EXTRACTOR_CJS_TRACE_WARNING?.toLowerCase() === 'true' ? console.trace : console.warn
+  log(
+    yellow(
+      'The CJS build of @extractus/feed-extractor is deprecated. See https://github.com/extractus/feed-extractor#cjs-deprecated for details.'
+    )
+  )
+}
+
+warnCjsUsage()
+
+export * from './main'


### PR DESCRIPTION
addresses #118

- use [esbuild](https://github.com/evanw/esbuild) to bundle a cjs compatible version of this package
- deprecate cjs in a similar way to vite, including a warning with environment variables to ignore or trace.

Let me know if and how you want me to add tests for this